### PR TITLE
fix(ios): non-continuous recognition timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-speech-recognition",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Speech Recognition for React Native Expo projects",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This PR fixes two issues with iOS when using `continuous: false`:

- On iOS 18 when a final result is detected, recognition should immediately stop to match the Web Speech API spec
- If `interimResults` is also turned off, the speech timeout timer shouldn't run out if the user speaks a long sentence without stopping 