### PR TITLE
fix: add type guards to web speech api

### DIFF
--- a/.changeset/sharp-shrimps-arrive.md
+++ b/.changeset/sharp-shrimps-arrive.md
@@ -1,0 +1,5 @@
+---
+"expo-speech-recognition": patch
+---
+
+Add type guards to Web Speech API to avoid unresolved references

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo-module": "expo-module",
     "open:ios": "open -a \"Xcode\" example/ios",
     "open:android": "open -a \"Android Studio\" example/android",
+    "changeset": "changeset",
     "release": "npm run prepare && changeset publish",
     "ts:check": "tsc -p . --noEmit"
   },

--- a/src/ExpoWebSpeechRecognition.web.ts
+++ b/src/ExpoWebSpeechRecognition.web.ts
@@ -4,12 +4,22 @@ let browserSpeechRecognitionEvent: typeof SpeechRecognitionEvent | null = null;
 
 if (typeof webkitSpeechRecognition !== "undefined") {
   browserSpeechRecognition = webkitSpeechRecognition;
-  browserSpeechGrammarList = webkitSpeechGrammarList;
-  browserSpeechRecognitionEvent = webkitSpeechRecognitionEvent;
+  browserSpeechGrammarList =
+    typeof webkitSpeechGrammarList !== "undefined"
+      ? webkitSpeechGrammarList
+      : null;
+  browserSpeechRecognitionEvent =
+    typeof webkitSpeechRecognitionEvent !== "undefined"
+      ? webkitSpeechRecognitionEvent
+      : null;
 } else if (typeof SpeechRecognition !== "undefined") {
   browserSpeechRecognition = SpeechRecognition;
-  browserSpeechGrammarList = SpeechGrammarList;
-  browserSpeechRecognitionEvent = SpeechRecognitionEvent;
+  browserSpeechGrammarList =
+    typeof SpeechGrammarList !== "undefined" ? SpeechGrammarList : null;
+  browserSpeechRecognitionEvent =
+    typeof SpeechRecognitionEvent !== "undefined"
+      ? SpeechRecognitionEvent
+      : null;
 }
 
 export const ExpoWebSpeechRecognition = browserSpeechRecognition;


### PR DESCRIPTION
Adds a few more checks to avoid reference errors when using the Web Speech API