### PR TITLE
fix(ios): handle restricted speech recognition

### DIFF
--- a/.changeset/fair-tires-walk.md
+++ b/.changeset/fair-tires-walk.md
@@ -1,0 +1,19 @@
+---
+"expo-speech-recognition": patch
+---
+
+Fix: restricted speech recognition permissions for iOS will now be classified as "denied" instead of "undetermined"
+
+You can now use `isSpeechRecognitionRestricted` to check whether speech recognition is restricted:
+
+```ts
+const permissions = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
+if (!permissions.granted) {
+  if (permissions.isSpeechRecognitionRestricted) {
+    // Ask user to enable speech recognition in Settings > Screen Time > Content & Privacy Restrictions
+  } else {
+    // Ask user to enable speech recognition for your app
+  }
+  return;
+}
+```

--- a/.changeset/fair-tires-walk.md
+++ b/.changeset/fair-tires-walk.md
@@ -10,7 +10,10 @@ You can now use `restricted` to check whether speech recognition is restricted:
 const permissions = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
 if (!permissions.granted) {
   if (permissions.restricted) {
-    // Ask user to enable speech recognition in Settings > Screen Time > Content & Privacy Restrictions
+    // Ask user to enable speech recognition on their device, either in:
+    // Settings -> Screen Time -> Content & Privacy Restrictions -> Speech Recognition
+    // or Settings -> General -> VPN & Device Management
+    // (if it is part of a MDM profile, see: https://support.apple.com/en-us/guide/deployment/depc0aadd3fe/web)
   } else {
     // Ask user to enable speech recognition for your app
   }

--- a/.changeset/fair-tires-walk.md
+++ b/.changeset/fair-tires-walk.md
@@ -4,12 +4,12 @@
 
 Fix: restricted speech recognition permissions for iOS will now be classified as "denied" instead of "undetermined"
 
-You can now use `isSpeechRecognitionRestricted` to check whether speech recognition is restricted:
+You can now use `restricted` to check whether speech recognition is restricted:
 
 ```ts
 const permissions = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
 if (!permissions.granted) {
-  if (permissions.isSpeechRecognitionRestricted) {
+  if (permissions.restricted) {
     // Ask user to enable speech recognition in Settings > Screen Time > Content & Privacy Restrictions
   } else {
     // Ask user to enable speech recognition for your app

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ import { ExpoSpeechRecognitionModule } from "expo-speech-recognition";
 ExpoSpeechRecognitionModule.getPermissionsAsync().then((result) => {
   console.log("Status:", result.status);
   console.log("Granted:", result.granted);
+  console.log("Restricted:", result.restricted);
   console.log("Can ask again:", result.canAskAgain);
   console.log("Expires:", result.expires);
 });

--- a/README.md
+++ b/README.md
@@ -809,6 +809,20 @@ If you're running a multimedia application with audio or video playback, you'll 
 - `ExpoSpeechRecognitionModule.start({ iosCategory })` to configure the audio session category and mode when speech recognition starts
 - `setAudioCategoryIOS({ category, categoryOptions, mode })` to set the audio session category and mode at a later point in time
 
+#### Permissions issues even though the app is explicitly allowed in Settings
+
+If the user has explicitly allowed your app **Microphone** and **Speech Recognition** permissions (under Settings > Apps > [your app]), this likely has something to do with the Speech Recognition permission.
+
+For a quick fix, you could enable `requiresOnDeviceSpeechRecognition` so that you don't use network-based speech recognition. You should also switch to using the [`requestMicrophonePermissionsAsync()`](#requestmicrophonepermissionsasync) function instead, which only requests the microphone permissions instead of both microphone and speech recognition. Keep in mind that you probably only want to do this with iOS.
+
+However, to diagnose the underlying issue:
+
+- Whether the user has enabled Content & Privacy Restrictions for Speech Recognition on their iOS device (Settings > Screen Time > Content & Privacy Restrictions > Speech Recognition)
+  - Remedy: Add, or disable the app from the list of apps under Speech Recognition
+- Whether the user is part of a Mobile device management (MDM) profile. This could make the speech recognition `restricted` (you can check for this in with the [`getPermissionsAsync()`](#getpermissionsasync) and [`requestPermissionsAsync()`](#requestpermissionsasync) APIs). To check for this Settings > General > VPN & Device Management
+  - Remedy: If the user is part of a managed profile, ask the MDM administrator to update the [Privacy Preferences Policy Control payload settings](https://support.apple.com/en-us/guide/deployment/dep38df53c2a/web) to allow your app to use speech recognition.
+- As usual, after changing any of these kinds of settings in the Settings app, a reboot may just "fix" it
+
 ## API Methods
 
 ### `start(options: SpeechRecognitionOptions): void`

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ import { ExpoSpeechRecognitionModule } from "expo-speech-recognition";
 ExpoSpeechRecognitionModule.getPermissionsAsync().then((result) => {
   console.log("Status:", result.status);
   console.log("Granted:", result.granted);
-  console.log("Restricted:", result.restricted);
+  console.log("Restricted:", result.restricted); // (iOS only)
   console.log("Can ask again:", result.canAskAgain);
   console.log("Expires:", result.expires);
 });
@@ -878,6 +878,7 @@ Once a user has granted (or denied) permissions by responding to the original pe
 ExpoSpeechRecognitionModule.requestPermissionsAsync().then((result) => {
   console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
   console.log("Granted:", result.granted); // true | false
+  console.log("Restricted:", result.restricted); // true | false | undefined (iOS only)
   console.log("Can ask again:", result.canAskAgain); // true | false
   console.log("Expires:", result.expires); // "never" | number
 });
@@ -920,6 +921,7 @@ if (!requiresOnDeviceRecognition && Platform.OS === "ios") {
     (result) => {
       console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
       console.log("Granted:", result.granted); // true | false
+      console.log("Restricted:", result.restricted); //true | false | undefined (iOS only)
       console.log("Can ask again:", result.canAskAgain); // true | false
       console.log("Expires:", result.expires); // "never" | number
     },
@@ -935,6 +937,7 @@ Returns the current permission status for both microphone and iOS speech recogni
 ExpoSpeechRecognitionModule.getPermissionsAsync().then((result) => {
   console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
   console.log("Granted:", result.granted); // true | false
+  console.log("Restricted:", result.restricted); //true | false | undefined (iOS only)
   console.log("Can ask again:", result.canAskAgain); // true | false
   console.log("Expires:", result.expires); // "never" | number
 });
@@ -965,6 +968,7 @@ ExpoSpeechRecognitionModule.getSpeechRecognizerPermissionsAsync().then(
   (result) => {
     console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
     console.log("Granted:", result.granted); // true | false
+    console.log("Restricted:", result.restricted); //true | false | undefined (iOS only)
     console.log("Can ask again:", result.canAskAgain); // true | false
     console.log("Expires:", result.expires); // "never" | number
   },

--- a/README.md
+++ b/README.md
@@ -819,8 +819,8 @@ However, to diagnose the underlying issue:
 
 - Whether the user has enabled Content & Privacy Restrictions for Speech Recognition on their iOS device (Settings > Screen Time > Content & Privacy Restrictions > Speech Recognition)
   - Remedy: Add, or disable the app from the list of apps under Speech Recognition
-- Whether the user is part of a Mobile device management (MDM) profile. This could make the speech recognition `restricted` (you can check for this in with the [`getPermissionsAsync()`](#getpermissionsasync) and [`requestPermissionsAsync()`](#requestpermissionsasync) APIs). To check for this Settings > General > VPN & Device Management
-  - Remedy: If the user is part of a managed profile, ask the MDM administrator to update the [Privacy Preferences Policy Control payload settings](https://support.apple.com/en-us/guide/deployment/dep38df53c2a/web) to allow your app to use speech recognition.
+- Whether the user is part of a Mobile device management (MDM) profile. This could make the speech recognition `restricted` (you can check for this in with the [`getPermissionsAsync()`](#getpermissionsasync) and [`requestPermissionsAsync()`](#requestpermissionsasync) APIs). To check for this, open Settings > General > VPN & Device Management.
+  - Remedy: If the user is part of a managed profile, ask the MDM administrator (usually your work) to update the [Privacy Preferences Policy Control payload settings](https://support.apple.com/en-us/guide/deployment/dep38df53c2a/web) to allow your app to use speech recognition.
 - As usual, after changing any of these kinds of settings in the Settings app, a reboot may just "fix" it
 
 ## API Methods

--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ If you're running a multimedia application with audio or video playback, you'll 
 
 If the user has explicitly allowed your app **Microphone** and **Speech Recognition** permissions (under Settings > Apps > [your app]), this likely has something to do with the Speech Recognition permission.
 
-For a quick fix, you could enable `requiresOnDeviceSpeechRecognition` so that you don't use network-based speech recognition. You should also switch to using the [`requestMicrophonePermissionsAsync()`](#requestmicrophonepermissionsasync) function instead, which only requests the microphone permissions instead of both microphone and speech recognition. Keep in mind that you probably only want to do this with iOS.
+For a quick fix, you could enable `requiresOnDeviceSpeechRecognition` so that you don't use network-based speech recognition (and therefore don't need Speech Recognition permissions). You should also switch to using the [`requestMicrophonePermissionsAsync()`](#requestmicrophonepermissionsasync) function instead, which only requests the microphone permissions instead of both microphone and speech recognition. Android doesn't have a dedicated speech recognition permission so it's safe to only request microphone permissions on both Android and iOS. Keep in mind though that the `requiresOnDeviceSpeechRecognition` setting for Android will require the language model to be installed.
 
 However, to diagnose the underlying issue:
 

--- a/README.md
+++ b/README.md
@@ -921,7 +921,7 @@ if (!requiresOnDeviceRecognition && Platform.OS === "ios") {
     (result) => {
       console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
       console.log("Granted:", result.granted); // true | false
-      console.log("Restricted:", result.restricted); //true | false | undefined (iOS only)
+      console.log("Restricted:", result.restricted); // true | false | undefined (iOS only)
       console.log("Can ask again:", result.canAskAgain); // true | false
       console.log("Expires:", result.expires); // "never" | number
     },
@@ -937,7 +937,7 @@ Returns the current permission status for both microphone and iOS speech recogni
 ExpoSpeechRecognitionModule.getPermissionsAsync().then((result) => {
   console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
   console.log("Granted:", result.granted); // true | false
-  console.log("Restricted:", result.restricted); //true | false | undefined (iOS only)
+  console.log("Restricted:", result.restricted); // true | false | undefined (iOS only)
   console.log("Can ask again:", result.canAskAgain); // true | false
   console.log("Expires:", result.expires); // "never" | number
 });
@@ -968,7 +968,7 @@ ExpoSpeechRecognitionModule.getSpeechRecognizerPermissionsAsync().then(
   (result) => {
     console.log("Status:", result.status); // "granted" | "denied" | "not-determined"
     console.log("Granted:", result.granted); // true | false
-    console.log("Restricted:", result.restricted); //true | false | undefined (iOS only)
+    console.log("Restricted:", result.restricted); // true | false | undefined (iOS only)
     console.log("Can ask again:", result.canAskAgain); // true | false
     console.log("Expires:", result.expires); // "never" | number
   },

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -150,8 +150,7 @@ export default function App() {
         if (speechRecognizerPermissions.restricted) {
           setError({
             error: "not-allowed",
-            message:
-              "Speech recognition is restricted. Please enable it in Settings > Screen Time > Content & Privacy Restrictions",
+            message: "Speech recognition is restricted.",
           });
         } else {
           setError({

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -147,7 +147,7 @@ export default function App() {
         await ExpoSpeechRecognitionModule.requestSpeechRecognizerPermissionsAsync();
       console.log("Speech recognizer permissions", speechRecognizerPermissions);
       if (!speechRecognizerPermissions.granted) {
-        if (speechRecognizerPermissions.isSpeechRecognitionRestricted) {
+        if (speechRecognizerPermissions.restricted) {
           setError({
             error: "not-allowed",
             message:

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -13,8 +13,6 @@ import {
 import {
   AudioEncodingAndroid,
   ExpoSpeechRecognitionModule,
-  getSpeechRecognitionServices,
-  getSupportedLocales,
   useSpeechRecognitionEvent,
   TaskHintIOS,
   AVAudioSessionCategory,
@@ -50,7 +48,8 @@ import {
 } from "expo-av/build/Audio";
 import { VolumeMeteringAvatar } from "./components/VolumeMeteringAvatar";
 
-const speechRecognitionServices = getSpeechRecognitionServices();
+const speechRecognitionServices =
+  ExpoSpeechRecognitionModule.getSpeechRecognitionServices();
 
 export default function App() {
   const [error, setError] = useState<{ error: string; message: string } | null>(
@@ -117,7 +116,7 @@ export default function App() {
     setError(ev);
   });
 
-  useSpeechRecognitionEvent("nomatch", (ev) => {
+  useSpeechRecognitionEvent("nomatch", () => {
     console.log("[event]: nomatch");
   });
 
@@ -148,7 +147,18 @@ export default function App() {
         await ExpoSpeechRecognitionModule.requestSpeechRecognizerPermissionsAsync();
       console.log("Speech recognizer permissions", speechRecognizerPermissions);
       if (!speechRecognizerPermissions.granted) {
-        setError({ error: "not-allowed", message: "Permissions not granted" });
+        if (speechRecognizerPermissions.isSpeechRecognitionRestricted) {
+          setError({
+            error: "not-allowed",
+            message:
+              "Speech recognition is restricted. Please enable it in Settings > Screen Time > Content & Privacy Restrictions",
+          });
+        } else {
+          setError({
+            error: "not-allowed",
+            message: "Permissions not granted",
+          });
+        }
         setStatus("idle");
         return;
       }
@@ -482,7 +492,7 @@ function GeneralSettings(props: {
   }>({ locales: [], installedLocales: [] });
 
   useEffect(() => {
-    getSupportedLocales({
+    ExpoSpeechRecognitionModule.getSupportedLocales({
       androidRecognitionServicePackage:
         settings.androidRecognitionServicePackage,
     })

--- a/ios/EXSpeechRecognitionPermissionRequester.swift
+++ b/ios/EXSpeechRecognitionPermissionRequester.swift
@@ -39,7 +39,7 @@ public class EXSpeechRecognitionPermissionRequester: NSObject, EXPermissionsRequ
 
     return [
       "status": status.rawValue,
-      "isSpeechRecognitionRestricted": speechPermission == .restricted,
+      "restricted": speechPermission == .restricted,
     ]
   }
 }

--- a/ios/EXSpeechRecognitionPermissionRequester.swift
+++ b/ios/EXSpeechRecognitionPermissionRequester.swift
@@ -29,14 +29,17 @@ public class EXSpeechRecognitionPermissionRequester: NSObject, EXPermissionsRequ
 
     if speechPermission == .authorized && recordPermission == .granted {
       status = EXPermissionStatusGranted
-    } else if speechPermission == .denied || recordPermission == .denied {
+    } else if speechPermission == .denied || recordPermission == .denied
+      || speechPermission == .restricted
+    {
       status = EXPermissionStatusDenied
     } else {
       status = EXPermissionStatusUndetermined
     }
 
     return [
-      "status": status.rawValue
+      "status": status.rawValue,
+      "isSpeechRecognitionRestricted": speechPermission == .restricted,
     ]
   }
 }

--- a/ios/SpeechRecognizerRequester.swift
+++ b/ios/SpeechRecognizerRequester.swift
@@ -21,14 +21,15 @@ public class SpeechRecognizerRequester: NSObject, EXPermissionsRequester {
 
     if speechPermission == .authorized {
       status = EXPermissionStatusGranted
-    } else if speechPermission == .denied {
+    } else if speechPermission == .denied || speechPermission == .restricted {
       status = EXPermissionStatusDenied
     } else {
       status = EXPermissionStatusUndetermined
     }
 
     return [
-      "status": status.rawValue
+      "status": status.rawValue,
+      "isSpeechRecognitionRestricted": speechPermission == .restricted,
     ]
   }
 }

--- a/ios/SpeechRecognizerRequester.swift
+++ b/ios/SpeechRecognizerRequester.swift
@@ -29,7 +29,7 @@ public class SpeechRecognizerRequester: NSObject, EXPermissionsRequester {
 
     return [
       "status": status.rawValue,
-      "isSpeechRecognitionRestricted": speechPermission == .restricted,
+      "restricted": speechPermission == .restricted,
     ]
   }
 }

--- a/src/ExpoSpeechRecognitionModule.types.ts
+++ b/src/ExpoSpeechRecognitionModule.types.ts
@@ -1,6 +1,15 @@
 import type { PermissionResponse } from "expo-modules-core";
 import type { NativeModule } from "expo";
 
+export type ExpoSpeechRecognitionPermissionResponse = PermissionResponse & {
+  /**
+   * Whether the speech recognition is restricted by Content & Privacy Restrictions.
+   *
+   * This is only available on iOS.
+   */
+  isSpeechRecognitionRestricted?: boolean;
+};
+
 import type {
   AudioEncodingAndroid,
   AVAudioSessionCategory,
@@ -584,7 +593,7 @@ export declare class ExpoSpeechRecognitionModuleType extends NativeModule<ExpoSp
    *
    * You may also use `getMicrophonePermissionsAsync` and `getSpeechRecognizerPermissionsAsync` to get the permissions separately.
    */
-  getPermissionsAsync(): Promise<PermissionResponse>;
+  getPermissionsAsync(): Promise<ExpoSpeechRecognitionPermissionResponse>;
   /**
    * Returns the current permission status for the microphone.
    */
@@ -599,7 +608,7 @@ export declare class ExpoSpeechRecognitionModuleType extends NativeModule<ExpoSp
   /**
    * Returns the current permission status for speech recognition.
    */
-  getSpeechRecognizerPermissionsAsync(): Promise<PermissionResponse>;
+  getSpeechRecognizerPermissionsAsync(): Promise<ExpoSpeechRecognitionPermissionResponse>;
   /**
    * [iOS only] Presents a dialog to the user to request permissions for using the speech recognizer.
    * This permission is required when `requiresOnDeviceRecognition` is disabled (i.e. network-based recognition)
@@ -607,7 +616,7 @@ export declare class ExpoSpeechRecognitionModuleType extends NativeModule<ExpoSp
    * For iOS, once a user has granted (or denied) permissions by responding to the original permission request dialog,
    * the only way that the permissions can be changed is by the user themselves using the device settings app.
    */
-  requestSpeechRecognizerPermissionsAsync(): Promise<PermissionResponse>;
+  requestSpeechRecognizerPermissionsAsync(): Promise<ExpoSpeechRecognitionPermissionResponse>;
   /**
    * Returns an array of locales supported by the speech recognizer.
    *

--- a/src/ExpoSpeechRecognitionModule.types.ts
+++ b/src/ExpoSpeechRecognitionModule.types.ts
@@ -5,9 +5,11 @@ export type ExpoSpeechRecognitionPermissionResponse = PermissionResponse & {
   /**
    * Whether the speech recognition is restricted by Content & Privacy Restrictions.
    *
+   * This value corresponds to the `restricted` enum of `SFSpeechRecognizer.authorizationStatus()`.
+   *
    * This is only available on iOS.
    */
-  isSpeechRecognitionRestricted?: boolean;
+  restricted?: boolean;
 };
 
 import type {
@@ -587,7 +589,7 @@ export declare class ExpoSpeechRecognitionModuleType extends NativeModule<ExpoSp
    * Once a user has granted (or denied) permissions by responding to the original permission request dialog,
    * the only way that the permissions can be changed is by the user themselves using the device settings app.
    */
-  requestPermissionsAsync(): Promise<PermissionResponse>;
+  requestPermissionsAsync(): Promise<ExpoSpeechRecognitionPermissionResponse>;
   /**
    * Returns the current permission status for speech recognition and the microphone.
    *


### PR DESCRIPTION
This PR covers the case where the user's device has restricted speech recognition through either:
- enabling Content & Privacy Restrictions for Speech Recognition on their iOS device. 
- or part of a MDM profile that prevents speech recognition 

This PR allows you now to provide feedback to the user so that they can turn it off, if necessary.

You can now use `restricted` to check whether speech recognition is restricted:

```ts
const permissions = await ExpoSpeechRecognitionModule.requestPermissionsAsync();
// (or requestSpeechRecognizerPermissionsAsync() for more granularity)

if (!permissions.granted) {
  if (permissions.restricted) {
    // Ask user to enable speech recognition on their device, either in:
    // Settings -> Screen Time -> Content & Privacy Restrictions -> Speech Recognition 
    // or Settings -> General -> VPN & Device Management (if it is a MDM profile, see: https://support.apple.com/en-us/guide/deployment/depc0aadd3fe/web)
  } else {
    // Ask user to enable speech recognition for your app
  }
  return;
}
```