### PR TITLE
feat: add async stop and abort methods

### DIFF
--- a/.changeset/petite-vans-warn.md
+++ b/.changeset/petite-vans-warn.md
@@ -1,0 +1,19 @@
+---
+"expo-speech-recognition": patch
+---
+
+Added `stopAsync()` and `abortAsync()` function helpers. These are the same as `stop()` and `abort()`, however they wait for the "end" event to be emitted.
+
+Usage:
+
+```js
+import { stopAsync, abortAsync } from "expo-speech-recognition";
+
+// Stopping will attempt to process the final result and end
+await stopAsync();
+console.log("Speech recognition has ended. We can safely call .start() again!");
+
+// Otherwise, you can abort and just wait till it ends:
+await abortAsync();
+console.log("Speech recognition has ended. We can safely call .start() again!");
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ expo-speech-recognition implements the iOS [`SFSpeechRecognizer`](https://develo
 - [API Methods](#api-methods)
   - [start()](#startoptions-speechrecognitionoptions-void)
   - [stop()](#stop-void)
+  - [stopAsync()](#stopasync-promisevoid)
   - [abort()](#abort-void)
+  - [abortAsync()](#abortasync-void)
   - [requestPermissionsAsync()](#requestpermissionsasync)
   - [requestMicrophonePermissionsAsync()](#requestmicrophonepermissionsasync)
   - [requestSpeechRecognizerPermissionsAsync()](#requestspeechrecognizerpermissionsasync)
@@ -872,6 +874,17 @@ ExpoSpeechRecognitionModule.stop();
 // - "end" indicating the end of speech recognition
 ```
 
+### `stopAsync(): Promise<void>`
+
+Does the same thing as `stop()` but waits for the "end" event to be emitted before resolving.
+
+```ts
+import { stopAsync } from "expo-speech-recognition";
+
+await stopAsync();
+console.log("Speech recognition has ended. We can safely call .start() again!");
+```
+
 ### `abort(): void`
 
 Immediately cancels speech recognition (does not process the final result).
@@ -881,6 +894,17 @@ ExpoSpeechRecognitionModule.abort();
 // Expect the following events to be emitted in order:
 // - "error" event with the code "aborted"
 // - "end" event indicating speech recognition has finished
+```
+
+### `abortAsync(): void`
+
+Does the same thing as `abort()` but waits for the "end" event to be emitted before resolving.
+
+```ts
+import { abortAsync } from "expo-speech-recognition";
+
+await abortAsync();
+console.log("Speech recognition has ended. We can safely call .start() again!");
 ```
 
 ### `requestPermissionsAsync()`

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,32 @@ export const getAssistantService =
 export const addSpeechRecognitionListener =
   ExpoSpeechRecognitionModule.addListener;
 
+/**
+ * Stops speech recognition and waits for the end event before resolving.
+ */
+export const stopAsync = (): Promise<void> => {
+  return new Promise((resolve) => {
+    const subscription = ExpoSpeechRecognitionModule.addListener("end", () => {
+      subscription.remove();
+      resolve();
+    });
+    ExpoSpeechRecognitionModule.stop();
+  });
+};
+
+/**
+ * Aborts speech recognition and waits for the end event before resolving.
+ */
+export const abortAsync = (): Promise<void> => {
+  return new Promise((resolve) => {
+    const subscription = ExpoSpeechRecognitionModule.addListener("end", () => {
+      subscription.remove();
+      resolve();
+    });
+    ExpoSpeechRecognitionModule.abort();
+  });
+};
+
 export type {
   ExpoSpeechRecognitionOptions,
   AndroidIntentOptions,


### PR DESCRIPTION
Adds `stopAsync()` and `abortAsync()` function helpers. Particularly useful for running code after speech recognition ends.