### PR TITLE
feat: native error codes (android)

### DIFF
--- a/.changeset/loose-cups-grin.md
+++ b/.changeset/loose-cups-grin.md
@@ -4,11 +4,11 @@
 
 Add native event error codes for Android.
 
-For advanced use cases where you'd like to debug the exact underlying SpeechRecognizer issue you can now access `event.code` from the error event. You can also use the `SpeechRecognizerErrorAndroid` enum on the event code.
+For advanced use cases where you'd like to debug the platform's underlying speech recognizer you can now access `event.code` from the error event. For Android, you can import the `SpeechRecognizerErrorAndroid` enum to match against this code.
 
 Error codes with the value of `-1` are thrown by this library and not by the `SpeechRecognizer`.
 
-For example, both `ERROR_NETWORK` and `ERROR_NETWORK_TIMEOUT` are mapped to `network` on `event.error`, but now with this change you can more easily discriminate between the errors:
+Example use case: differentiating between `ERROR_NETWORK` and `ERROR_NETWORK_TIMEOUT` are currently mapped to `network` on `event.error`. With this change you can now use `event.code` to see the exact error that was thrown.
 
 ```ts
 import {

--- a/.changeset/loose-cups-grin.md
+++ b/.changeset/loose-cups-grin.md
@@ -1,0 +1,32 @@
+---
+"expo-speech-recognition": patch
+---
+
+Add native event error codes for Android.
+
+For advanced use cases where you'd like to debug the exact underlying SpeechRecognizer issue you can now access `event.code` from the error event. You can also use the `SpeechRecognizerErrorAndroid` enum on the event code.
+
+Error codes with the value of `-1` are thrown by this library and not by the `SpeechRecognizer`.
+
+For example, both `ERROR_NETWORK` and `ERROR_NETWORK_TIMEOUT` are mapped to `network` on `event.error`, but now with this change you can more easily discriminate between the errors:
+
+```ts
+import {
+  SpeechRecognizerErrorAndroid,
+  useSpeechRecognitionEvent,
+} from "expo-speech-recognition";
+
+useSpeechRecognitionEvent("error", (event) => {
+  if (Platform.OS === "android") {
+    switch (event.code) {
+      case SpeechRecognizerErrorAndroid.ERROR_NETWORK:
+        break;
+      case SpeechRecognizerErrorAndroid.ERROR_NETWORK_TIMEOUT:
+        break;
+      case -1:
+        // An error usually thrown by the this library
+        break;
+    }
+  }
+});
+```

--- a/README.md
+++ b/README.md
@@ -417,16 +417,8 @@ import {
 } from "expo-speech-recognition";
 
 useSpeechRecognitionEvent("error", (event) => {
-  if (Platform.OS === "android") {
-    switch (event.code) {
-      case SpeechRecognizerErrorAndroid.ERROR_NETWORK_TIMEOUT:
-        break; // do something
-      case SpeechRecognizerErrorAndroid.ERROR_TOO_MANY_REQUESTS:
-        break;
-      case -1:
-        // An error usually thrown by the this library
-        break;
-    }
+  if (event.code === SpeechRecognizerErrorAndroid.ERROR_NETWORK_TIMEOUT) {
+    // do something
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ expo-speech-recognition implements the iOS [`SFSpeechRecognizer`](https://develo
   - [Direct module API](#direct-module-api)
 - [Speech Recognition Events](#speech-recognition-events)
 - [Handling Errors](#handling-errors)
+  - [Advanced error handling](#advanced-error-handling)
 - [Persisting Audio Recordings](#persisting-audio-recordings)
 - [Transcribing audio files](#transcribing-audio-files)
   - [Supported input audio formats](#supported-input-audio-formats)
@@ -402,6 +403,33 @@ The error code is based on the [Web Speech API error codes](https://developer.mo
 | `client`                 | An unknown client-side error. Corresponds with `SpeechRecognizer.ERROR_CLIENT`. |
 | `speech-timeout`         | (Android) No speech input.                                                      |
 | `unknown`                | (Android) Unknown error                                                         |
+
+### Advanced error handling
+
+Alongside the the mapped web-speech API error name, you can also access the `error.code` field to get the exact error that the `SpeechRecognizer` has thrown.
+
+This is currently supported on Android only.
+
+```ts
+import {
+  SpeechRecognizerErrorAndroid,
+  useSpeechRecognitionEvent,
+} from "expo-speech-recognition";
+
+useSpeechRecognitionEvent("error", (event) => {
+  if (Platform.OS === "android") {
+    switch (event.code) {
+      case SpeechRecognizerErrorAndroid.ERROR_NETWORK_TIMEOUT:
+        break; // do something
+      case SpeechRecognizerErrorAndroid.ERROR_TOO_MANY_REQUESTS:
+        break;
+      case -1:
+        // An error usually thrown by the this library
+        break;
+    }
+  }
+});
+```
 
 ## Persisting Audio Recordings
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ The error code is based on the [Web Speech API error codes](https://developer.mo
 
 ### Advanced error handling
 
-Alongside the the mapped web-speech API error name, you can also access the `error.code` field to get the exact error that the `SpeechRecognizer` has thrown.
+Alongside the the mapped web-speech API error name, you can also access the `error.code` field to get the platform's underlying native error code.
 
 This is currently supported on Android only.
 

--- a/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechRecognitionModule.kt
+++ b/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechRecognitionModule.kt
@@ -201,7 +201,7 @@ class ExpoSpeechRecognitionModule : Module() {
             /** Start recognition with args: lang, interimResults, maxAlternatives */
             Function("start") { options: SpeechRecognitionOptions ->
                 if (hasNotGrantedRecordPermissions()) {
-                    sendEvent("error", mapOf("error" to "not-allowed", "message" to "Missing RECORD_AUDIO permissions."))
+                    sendEvent("error", mapOf("error" to "not-allowed", "message" to "Missing RECORD_AUDIO permissions.", "code" to -1))
                     sendEvent("end")
                     return@Function
                 }
@@ -213,7 +213,7 @@ class ExpoSpeechRecognitionModule : Module() {
             }
 
             Function("abort") {
-                sendEvent("error", mapOf("error" to "aborted", "message" to "Speech recognition aborted."))
+                sendEvent("error", mapOf("error" to "aborted", "message" to "Speech recognition aborted.", "code" to -1))
                 expoSpeechService.abort()
             }
 

--- a/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechService.kt
+++ b/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechService.kt
@@ -157,7 +157,7 @@ class ExpoSpeechService(
                     }
                 e.printStackTrace()
                 log("Failed to create Speech Recognizer with error: $errorMessage")
-                sendEvent("error", mapOf("error" to "audio-capture", "message" to errorMessage))
+                sendEvent("error", mapOf("error" to "audio-capture", "message" to errorMessage, "code" to -1))
                 teardownAndEnd()
             }
         }
@@ -521,7 +521,7 @@ class ExpoSpeechService(
             sendEvent("nomatch", null)
         }
 
-        sendEvent("error", mapOf("error" to errorInfo.error, "message" to errorInfo.message))
+        sendEvent("error", mapOf("error" to errorInfo.error, "message" to errorInfo.message, "code" to error))
         teardownAndEnd(RecognitionState.ERROR)
         log("onError() - ${errorInfo.error}: ${errorInfo.message} - code: $error")
     }
@@ -703,7 +703,7 @@ class ExpoSpeechService(
                 // Extra codes
                 SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "speech-timeout"
                 SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "busy"
-                SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "busy"
+                SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "too-many-requests"
                 else -> "unknown"
             }
 
@@ -722,7 +722,7 @@ class ExpoSpeechService(
                     "Requested language is not available to be used with the current recognizer."
                 // Extra codes/messages
                 SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "RecognitionService busy."
-                SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "Too many requests."
+                SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "Too many requests from the same client."
                 SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "No speech input."
                 else -> "Unknown error"
             }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,7 @@ import {
   AVAudioSessionCategoryOptions,
   AVAudioSessionMode,
   ExpoWebSpeechRecognition,
+  SpeechRecognizerErrorAndroid,
 } from "expo-speech-recognition";
 import type {
   AudioEncodingAndroidValue,
@@ -112,7 +113,22 @@ export default function App() {
   });
 
   useSpeechRecognitionEvent("error", (ev) => {
-    console.log("[event]: error", ev.error, ev.message);
+    console.log(
+      "[event]: error",
+      ev.error,
+      ev.message,
+      ev.code ? `code: ${ev.code}` : "",
+    );
+
+    switch (ev.code) {
+      case SpeechRecognizerErrorAndroid.ERROR_NETWORK_TIMEOUT:
+        break;
+      case SpeechRecognizerErrorAndroid.ERROR_TOO_MANY_REQUESTS:
+        break;
+      case -1:
+        break;
+    }
+
     setError(ev);
   });
 

--- a/src/ExpoSpeechRecognitionModule.types.ts
+++ b/src/ExpoSpeechRecognitionModule.types.ts
@@ -97,6 +97,15 @@ export type ExpoSpeechRecognitionErrorCode =
 export type ExpoSpeechRecognitionErrorEvent = {
   error: ExpoSpeechRecognitionErrorCode;
   message: string;
+  /**
+   * The underlying native error code from the platform-specific speech recognition service.
+   *
+   * - On Android: Maps to SpeechRecognizer error constants (e.g., ERROR_AUDIO = 3)
+   * - Value of -1 indicates a generic/unknown error or when native code is not available
+   *
+   * Usually you won't need this field, but it can be useful for debugging purposes.
+   */
+  code?: number;
 };
 
 export type LanguageDetectionEvent = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -347,3 +347,41 @@ export const TaskHintIOS = {
    */
   confirmation: "confirmation",
 } as const;
+
+/**
+ * An enum of the error codes for the Android SpeechRecognizer class.
+ *
+ * Docs: https://developer.android.com/reference/android/speech/SpeechRecognizer
+ */
+export const SpeechRecognizerErrorAndroid = {
+  /** Audio recording error. */
+  ERROR_AUDIO: 3,
+  /** (API 33+) The service does not allow to check for support. */
+  ERROR_CANNOT_CHECK_SUPPORT: 14,
+  /** (API 33+) The service does not support listening to model downloads events. */
+  ERROR_CANNOT_LISTEN_TO_DOWNLOAD_EVENTS: 15,
+  /** Other client side errors. */
+  ERROR_CLIENT: 5,
+  /** Insufficient permissions */
+  ERROR_INSUFFICIENT_PERMISSIONS: 9,
+  /** Requested language is not available to be used with the current recognizer. */
+  ERROR_LANGUAGE_NOT_SUPPORTED: 12,
+  /** (API 31+) Requested language is supported, but not available currently (e.g. not downloaded yet). */
+  ERROR_LANGUAGE_UNAVAILABLE: 13,
+  /** Other network related errors. */
+  ERROR_NETWORK: 2,
+  /** Network operation timed out. */
+  ERROR_NETWORK_TIMEOUT: 1,
+  /** No recognition result matched. */
+  ERROR_NO_MATCH: 7,
+  /** RecognitionService busy. */
+  ERROR_RECOGNIZER_BUSY: 8,
+  /** Server sends error status. */
+  ERROR_SERVER: 4,
+  /** Server has been disconnected, e.g. because the app has crashed. */
+  ERROR_SERVER_DISCONNECTED: 11,
+  /** No speech input */
+  ERROR_SPEECH_TIMEOUT: 6,
+  /** (API 31+) Too many requests from the same client. */
+  ERROR_TOO_MANY_REQUESTS: 10,
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   RecognizerIntentEnableLanguageSwitch,
   AudioEncodingAndroid,
   TaskHintIOS,
+  SpeechRecognizerErrorAndroid,
 } from "./constants";
 
 export const getSupportedLocales = (options?: {


### PR DESCRIPTION
For advanced use cases where you'd like to debug the exact underlying SpeechRecognizer issue you can now access `event.code` from the error event. You can also use the `SpeechRecognizerErrorAndroid` enum on the event code.

Error codes with the value of `-1` are thrown by this library and not by the `SpeechRecognizer`.

For example, both `ERROR_NETWORK` and `ERROR_NETWORK_TIMEOUT` are mapped to `network` on `event.error`, but now with this change you can more easily discriminate between the errors:

```ts
import {
  SpeechRecognizerErrorAndroid,
  useSpeechRecognitionEvent,
} from "expo-speech-recognition";

useSpeechRecognitionEvent("error", (event) => {
  if (Platform.OS === "android") {
    switch (event.code) {
      case SpeechRecognizerErrorAndroid.ERROR_NETWORK:
        break;
      case SpeechRecognizerErrorAndroid.ERROR_NETWORK_TIMEOUT:
        break;
      case -1:
        // An error usually thrown by the this library
        break;
    }
  }
});
```