### PR TITLE
enable AcousticEchoCanceler

### DIFF
--- a/android/src/main/java/expo/modules/speechrecognition/ExpoAudioRecorder.kt
+++ b/android/src/main/java/expo/modules/speechrecognition/ExpoAudioRecorder.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.media.audiofx.AcousticEchoCanceler
 import android.os.ParcelFileDescriptor
 import android.os.ParcelFileDescriptor.AutoCloseOutputStream
 import android.os.Build
@@ -134,7 +135,7 @@ class ExpoAudioRecorder(
     @SuppressLint("MissingPermission")
     private fun createRecorder(): AudioRecord =
         AudioRecord(
-            MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            MediaRecorder.AudioSource.VOICE_COMMUNICATION,
             sampleRateInHz,
             channelConfig,
             AudioFormat.ENCODING_PCM_16BIT,
@@ -148,6 +149,10 @@ class ExpoAudioRecorder(
             // First check whether the above object actually initialized
             if (this.state != AudioRecord.STATE_INITIALIZED) {
                 return
+            }
+
+            if (AcousticEchoCanceler.isAvailable()) {
+                AcousticEchoCanceler.create(recorder.audioSessionId)?.enabled = true
             }
 
             this.startRecording()


### PR DESCRIPTION
On my Pixel 4a, `MediaRecorder.AudioSource.VOICE_COMMUNICATION` is necessary. [Docs](https://developer.android.com/reference/android/media/MediaRecorder.AudioSource#VOICE_COMMUNICATION) indicate this too:

> Microphone audio source tuned for voice communications such as VoIP. It will for instance take advantage of echo cancellation or automatic gain control if available.

---

[AEC docs state](https://developer.android.com/reference/android/media/audiofx/AcousticEchoCanceler):

> AEC is often used in conjunction with noise suppression (NS).

So a future(?) improvement may be to expose an option to enable [NoiseSuppressor](https://developer.android.com/reference/android/media/audiofx/NoiseSuppressor).

Other potentially useful audiofx include:

* https://developer.android.com/reference/android/media/audiofx/AutomaticGainControl
* https://developer.android.com/reference/android/media/audiofx/LoudnessEnhancer (though I imagine most people would prefer `AutomaticGainControl`.

---

I'm leaving this as a draft because you may wish to make AEC opt-in, since it changes the `MediaRecorder.AudioSource`, and I'm not sure what kind of (typescript) API you want to expose for that. Please feel free to close this PR and do whatever you wish - I'm currently using `pnpm patch` to use this in my own proj.