### PR TITLE
fix(ios): Remove tvos from the podspec

### DIFF
--- a/.changeset/lucky-lamps-crash.md
+++ b/.changeset/lucky-lamps-crash.md
@@ -1,0 +1,5 @@
+---
+"expo-speech-recognition": patch
+---
+
+Removed tvOS from the podspec, as Speech API is not available there

--- a/ios/ExpoSpeechRecognition.podspec
+++ b/ios/ExpoSpeechRecognition.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platforms      = { :ios => '13.4', :tvos => '13.4' }
+  s.platforms      = { :ios => '13.4' }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/jamsch/expo-speech-recognition' }
   s.static_framework = true


### PR DESCRIPTION
Speech API is not available on tvOS -> https://developer.apple.com/documentation/speech

We use this library on Android TV, but it won't work on tvOS. To avoid build failures, the pod shouldn't be installed there.