### PR TITLE
feat: add HarmonyOS speech recognition

### DIFF
--- a/.changeset/brave-pandas-listen.md
+++ b/.changeset/brave-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+"expo-speech-recognition": patch
+---
+
+Add HarmonyOS API 22 speech recognition through Expo Harmony Route 3 autolinking, including live microphone and local PCM/WAV audio-source transcription with the existing public API. Restore strict TypeScript 6 compatibility for the web polyfill.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -24,3 +25,6 @@ jobs:
 
       - name: 🛠️ Run the build
         run: npm run prepare
+
+      - name: 🧪 Run tests
+        run: npm test -- --runInBand

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,14 @@ yarn-error.log
 # Expo
 .expo/*
 
+# HarmonyOS
+harmony/.hvigor/
+harmony/build/
+harmony/oh_modules/
+harmony/local.properties
+*.har
+*.hap
+
 # Test assets
 example/assets/audio/test/
 example/android/

--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,12 @@ __tests__
 /.prettierignore
 /eslint.config.mjs
 /CHANGELOG.md
+
+# HarmonyOS build products and machine-local configuration
+/harmony/.hvigor/
+/harmony/build/
+/harmony/oh_modules/
+/harmony/local.properties
+/harmony/deveco-cli.toml
+*.har
+*.hap

--- a/README.md
+++ b/README.md
@@ -131,6 +131,65 @@ Now, you're ready to move on to the [Usage](#usage) section.
 
 </details>
 
+### HarmonyOS
+
+HarmonyOS support uses the same public JavaScript API as iOS, Android, and web.
+It requires an Expo SDK build that includes Expo's Harmony Route 3 runtime,
+autolinking, config plugins, and CLI support. The stock Expo Go app cannot load
+this native module.
+
+With a Harmony-enabled Expo SDK, install this package normally and run:
+
+```bash
+npx expo prebuild --platform harmony
+npx expo run:harmony
+```
+
+The Harmony implementation targets API 22 and declares the microphone,
+internet, Core Speech Kit, and Audio Capturer requirements through
+`expo-module.config.json`. No manual HAR copying or native project edits are
+required.
+
+Live microphone recognition uses the regular `start()`, `stop()`, and
+`abort()` methods. Local audio files use the community `audioSource` option
+and return transcription through `result` events:
+
+```ts
+import {
+  AudioEncodingAndroid,
+  ExpoSpeechRecognitionModule,
+} from "expo-speech-recognition";
+
+const resultSubscription = ExpoSpeechRecognitionModule.addListener(
+  "result",
+  ({ isFinal, results }) => {
+    if (isFinal) {
+      console.log(results[0]?.transcript);
+    }
+  },
+);
+const endSubscription = ExpoSpeechRecognitionModule.addListener("end", () => {
+  resultSubscription.remove();
+  endSubscription.remove();
+});
+
+ExpoSpeechRecognitionModule.start({
+  lang: "zh-CN",
+  interimResults: false,
+  audioSource: {
+    uri: "file:///path/to/16khz-mono-pcm.wav",
+    sampleRate: 16000,
+    audioChannels: 1,
+    audioEncoding: AudioEncodingAndroid.ENCODING_PCM_16BIT,
+  },
+});
+```
+
+Harmony file input currently supports local `asset://`, `file://`, and
+absolute paths containing raw PCM or WAV audio that is 16 kHz, mono, signed
+16-bit little-endian. Remote URLs and other codecs fail with an
+`audio-capture` error instead of reporting a false success.
+
 ## Usage
 
 ### Using Hooks
@@ -779,7 +838,7 @@ ExpoSpeechRecognitionModule.start({
 
 ## Platform Compatibility Table
 
-As of 12 July 2025, the following platforms are supported:
+The following platforms are supported:
 
 ### Mobile Platforms (React Native)
 
@@ -798,6 +857,21 @@ As of 12 July 2025, the following platforms are supported:
 | **Language Detection**              | ❌          | ❌         | ✅ \*       | ❌      | \*Android: only with on-device recognition                                      |
 | **Word Confidence & Timing**        | ❌          | ❌         | ✅ \*       | ✅      | \*Android: only with on-device recognition                                      |
 | **Offensive Word Masking**          | ❌          | ✅         | ✅          | ❌      | Android 13+ with `EXTRA_MASK_OFFENSIVE_WORDS` enabled in `androidIntentOptions` |
+
+### HarmonyOS API 22
+
+| Feature                              | Support | Notes                                                                                                    |
+| ------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
+| **Basic Speech Recognition**         | ✅      | Core Speech Kit with the public module API and event shapes                                              |
+| **Interim Results**                  | ✅      | Controlled by `interimResults`                                                                           |
+| **On-Device Recognition**            | ✅      | `requiresOnDeviceRecognition` selects the offline engine; the requested language model must be installed |
+| **Audio File Transcription**         | ✅      | Local 16 kHz mono signed-16 PCM/WAV through `audioSource`                                                |
+| **Continuous Recognition**           | Partial | Core Speech Kit owns utterance and session termination                                                   |
+| **Audio Recording**                  | ❌      | `supportsRecording()` returns false; `recordingOptions.persist` emits `audio-capture`                    |
+| **Multiple Alternatives**            | ❌      | Harmony returns one alternative with confidence `-1` and no word segments                                |
+| **Contextual Strings / Punctuation** | ❌      | Options are accepted for API compatibility but are not applied                                           |
+| **Volume / Language Detection**      | ❌      | Event names are registered, but Harmony does not synthesize unsupported native data                      |
+| **Remote Audio URLs / Other Codecs** | ❌      | Use a local 16 kHz mono signed-16 PCM/WAV file                                                           |
 
 ### Web Platforms
 

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -1,9 +1,29 @@
 {
-  "platforms": ["ios", "android", "web"],
+  "platforms": ["ios", "android", "web", "harmony"],
   "ios": {
     "modules": ["ExpoSpeechRecognitionModule"]
   },
   "android": {
     "modules": ["expo.modules.speechrecognition.ExpoSpeechRecognitionModule"]
+  },
+  "harmony": {
+    "modules": ["ExpoSpeechRecognition"],
+    "arktsPackageClass": "ExpoSpeechRecognitionHarmonyPackage",
+    "ohPackageName": "@bitfun/expo-speech-recognition-harmony",
+    "harName": "expo_speech_recognition_harmony.har",
+    "requiredSysCaps": [
+      "SystemCapability.AI.SpeechRecognizer",
+      "SystemCapability.Multimedia.Audio.Capturer"
+    ],
+    "permissions": [
+      {
+        "name": "ohos.permission.INTERNET"
+      },
+      {
+        "name": "ohos.permission.MICROPHONE",
+        "reason": "Allow the app to recognize speech from the microphone."
+      }
+    ],
+    "minApi": 22
   }
 }

--- a/harmony/build-profile.json5
+++ b/harmony/build-profile.json5
@@ -1,0 +1,9 @@
+{
+  apiType: "stageMode",
+  targets: [
+    {
+      name: "default",
+      runtimeOS: "HarmonyOS",
+    },
+  ],
+}

--- a/harmony/hvigor/hvigor-config.json5
+++ b/harmony/hvigor/hvigor-config.json5
@@ -1,0 +1,4 @@
+{
+  modelVersion: "5.0.0",
+  dependencies: {},
+}

--- a/harmony/hvigorfile.ts
+++ b/harmony/hvigorfile.ts
@@ -1,0 +1,3 @@
+import { harTasks } from "@ohos/hvigor-ohos-plugin";
+
+export default { system: harTasks, plugins: [] };

--- a/harmony/oh-package.json5
+++ b/harmony/oh-package.json5
@@ -1,0 +1,13 @@
+{
+  modelVersion: "5.0.0",
+  name: "@bitfun/expo-speech-recognition-harmony",
+  version: "0.1.0",
+  main: "src/main/ets/Index.ets",
+  dependencies: {
+    "@rnoh/react-native-openharmony": "file:../../../expo/node_modules/@react-native-oh/react-native-harmony/react_native_openharmony.har",
+    "@expo/expo-modules-core": "file:../../expo-modules-core/harmony/build/default/outputs/default/expo_modules_core_harmony.har",
+  },
+  overrides: {
+    "@rnoh/react-native-openharmony": "file:../../../expo/node_modules/@react-native-oh/react-native-harmony/react_native_openharmony.har",
+  },
+}

--- a/harmony/src/main/ets/Index.ets
+++ b/harmony/src/main/ets/Index.ets
@@ -1,0 +1,1017 @@
+/**
+ * ExpoSpeechRecognition for HarmonyOS.
+ *
+ * The module keeps the public API and event payloads of the community
+ * expo-speech-recognition package. Live sessions capture 16 kHz mono signed-16
+ * PCM through Audio Kit and stream 640-byte frames into Core Speech Kit. File
+ * sessions accept local raw PCM or RIFF/WAVE files with the same audio format.
+ */
+import type { RNPackageContext } from '@rnoh/react-native-openharmony';
+import { RNOHPackage } from '@rnoh/react-native-openharmony';
+import type { AppContext, ExpoValue } from '@expo/expo-modules-core';
+import {
+  Module,
+  ModuleDefinition,
+  expoRoute3ModuleRegistry,
+} from '@expo/expo-modules-core';
+import { speechRecognizer } from '@kit.CoreSpeechKit';
+import audio from '@ohos.multimedia.audio';
+import fs from '@ohos.file.fs';
+import abilityAccessCtrl from '@ohos.abilityAccessCtrl';
+import type { Permissions } from '@ohos.abilityAccessCtrl';
+
+const MODULE_NAME: string = 'ExpoSpeechRecognition';
+const ASR_SYSCAP: string = 'SystemCapability.AI.SpeechRecognizer';
+const AUDIO_SYSCAP: string = 'SystemCapability.Multimedia.Audio.Capturer';
+const MICROPHONE_PERMISSION: Permissions = 'ohos.permission.MICROPHONE';
+const FRAME_BYTES: number = 640;
+const DEFAULT_LANGUAGE: string = 'en-US';
+const DEFAULT_CHUNK_DELAY_MS: number = 20;
+const PCM_16BIT_ANDROID_ENCODING: number = 2;
+
+type RecognitionState = 'inactive' | 'starting' | 'recognizing' | 'stopping';
+type SessionKind = 'microphone' | 'audioFile';
+
+interface AudioSourceOptions {
+  uri: string;
+  audioChannels?: number;
+  audioEncoding?: number;
+  sampleRate?: number;
+  chunkDelayMillis?: number;
+}
+
+interface RecordingOptions {
+  persist?: boolean;
+}
+
+interface RecognitionOptions {
+  lang?: string;
+  interimResults?: boolean;
+  maxAlternatives?: number;
+  contextualStrings?: Array<string>;
+  continuous?: boolean;
+  requiresOnDeviceRecognition?: boolean;
+  addsPunctuation?: boolean;
+  audioSource?: AudioSourceOptions;
+  recordingOptions?: RecordingOptions;
+}
+
+interface PermissionResponse {
+  status: string;
+  granted: boolean;
+  canAskAgain: boolean;
+  expires: string;
+}
+
+interface NativeError {
+  code?: number;
+  message?: string;
+}
+
+interface AudioFileData {
+  bytes: Uint8Array;
+  sampleRate: number;
+  channels: number;
+  sampleBits: number;
+  chunkDelayMillis: number;
+}
+
+interface RecognitionResultItemPayload {
+  transcript: string;
+  confidence: number;
+  segments: Array<ExpoValue>;
+}
+
+interface RecognitionResultPayload {
+  isFinal: boolean;
+  results: Array<RecognitionResultItemPayload>;
+}
+
+interface RecognitionErrorPayload {
+  error: string;
+  message: string;
+  code?: number;
+}
+
+interface RecognitionOwner {
+  onNativeStart(sessionId: string, eventMessage: string): void;
+  onNativeEvent(sessionId: string, eventCode: number, eventMessage: string): void;
+  onNativeResult(sessionId: string, result: speechRecognizer.SpeechRecognitionResult): void;
+  onNativeComplete(sessionId: string, eventMessage: string): void;
+  onNativeError(sessionId: string, errorCode: number, errorMessage: string): void;
+}
+
+class RecognitionListenerAdapter implements speechRecognizer.RecognitionListener {
+  private owner: RecognitionOwner;
+
+  constructor(owner: RecognitionOwner) {
+    this.owner = owner;
+  }
+
+  onStart(sessionId: string, eventMessage: string): void {
+    this.owner.onNativeStart(sessionId, eventMessage);
+  }
+
+  onEvent(sessionId: string, eventCode: number, eventMessage: string): void {
+    this.owner.onNativeEvent(sessionId, eventCode, eventMessage);
+  }
+
+  onResult(sessionId: string, result: speechRecognizer.SpeechRecognitionResult): void {
+    this.owner.onNativeResult(sessionId, result);
+  }
+
+  onComplete(sessionId: string, eventMessage: string): void {
+    this.owner.onNativeComplete(sessionId, eventMessage);
+  }
+
+  onError(sessionId: string, errorCode: number, errorMessage: string): void {
+    this.owner.onNativeError(sessionId, errorCode, errorMessage);
+  }
+}
+
+class ExpoSpeechRecognitionModule extends Module implements RecognitionOwner {
+  static readonly NAME: string = MODULE_NAME;
+  private readonly moduleDefinition: ModuleDefinition;
+
+  private state: RecognitionState = 'inactive';
+  private generation: number = 0;
+  private sessionKind: SessionKind | null = null;
+  private sessionId: string = '';
+  private engine: speechRecognizer.SpeechRecognitionEngine | null = null;
+  private capturer: audio.AudioCapturer | null = null;
+  private audioRemainder: Uint8Array = new Uint8Array(0);
+  private pendingFile: AudioFileData | null = null;
+  private lastTranscript: string = '';
+  private hasFinalResult: boolean = false;
+  private reportInterimResults: boolean = false;
+  private emittedAudioStart: boolean = false;
+  private emittedAudioEnd: boolean = false;
+  private emittedEnd: boolean = false;
+  private cleanupPromise: Promise<void> = Promise.resolve();
+  private readonly readDataCallback: (buffer: ArrayBuffer) => void;
+
+  constructor(appContext: AppContext) {
+    super(appContext);
+    this.readDataCallback = (buffer: ArrayBuffer): void => this.writeCapturedAudio(buffer);
+    this.moduleDefinition = new ModuleDefinition(ExpoSpeechRecognitionModule.NAME)
+      .event('audiostart')
+      .event('audioend')
+      .event('end')
+      .event('error')
+      .event('nomatch')
+      .event('result')
+      .event('soundstart')
+      .event('soundend')
+      .event('speechstart')
+      .event('speechend')
+      .event('start')
+      .event('languagedetection')
+      .event('volumechange')
+      .function('start', (args: ExpoValue[]): ExpoValue => {
+        this.startFromJavaScript(args[0] as RecognitionOptions);
+        return undefined;
+      }, 1, 1)
+      .function('stop', (_args: ExpoValue[]): ExpoValue => {
+        this.stopFromJavaScript();
+        return undefined;
+      })
+      .function('abort', (_args: ExpoValue[]): ExpoValue => {
+        this.abortFromJavaScript();
+        return undefined;
+      })
+      .asyncFunction('requestPermissionsAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return await this.requestMicrophonePermission();
+      })
+      .asyncFunction('getPermissionsAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return await this.getMicrophonePermission();
+      })
+      .asyncFunction('requestMicrophonePermissionsAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return await this.requestMicrophonePermission();
+      })
+      .asyncFunction('getMicrophonePermissionsAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return await this.getMicrophonePermission();
+      })
+      .asyncFunction('requestSpeechRecognizerPermissionsAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return this.speechRecognizerPermission();
+      })
+      .asyncFunction('getSpeechRecognizerPermissionsAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return this.speechRecognizerPermission();
+      })
+      .asyncFunction('getStateAsync', async (_args: ExpoValue[]): Promise<ExpoValue> => this.state)
+      .asyncFunction('getSupportedLocales', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        return await this.getSupportedLocales();
+      }, 0, 1)
+      .function('getSpeechRecognitionServices', (_args: ExpoValue[]): ExpoValue => {
+        return new Array<string>();
+      })
+      .function('getDefaultRecognitionService', (_args: ExpoValue[]): ExpoValue => {
+        return { packageName: '' };
+      })
+      .function('getAssistantService', (_args: ExpoValue[]): ExpoValue => {
+        return { packageName: '' };
+      })
+      .function('supportsOnDeviceRecognition', (_args: ExpoValue[]): ExpoValue => {
+        return canIUse(ASR_SYSCAP);
+      })
+      .function('supportsRecording', (_args: ExpoValue[]): ExpoValue => false)
+      .function('isRecognitionAvailable', (_args: ExpoValue[]): ExpoValue => this.available())
+      .asyncFunction('androidTriggerOfflineModelDownload', async (_args: ExpoValue[]): Promise<ExpoValue> => {
+        throw new Error('androidTriggerOfflineModelDownload is not supported on HarmonyOS.');
+      }, 1, 1)
+      .function('setCategoryIOS', (_args: ExpoValue[]): ExpoValue => undefined, 1, 1)
+      .function('getAudioSessionCategoryAndOptionsIOS', (_args: ExpoValue[]): ExpoValue => {
+        return {
+          category: 'playAndRecord',
+          categoryOptions: ['defaultToSpeaker', 'allowBluetooth'],
+          mode: 'measurement',
+        };
+      })
+      .function('setAudioSessionActiveIOS', (_args: ExpoValue[]): ExpoValue => undefined, 1, 2);
+  }
+
+  override definition(): ModuleDefinition {
+    return this.moduleDefinition;
+  }
+
+  override onDestroy(): void {
+    this.cancelNativeWork();
+  }
+
+  private available(): boolean {
+    return canIUse(ASR_SYSCAP) && canIUse(AUDIO_SYSCAP);
+  }
+
+  private safeEmit(name: string, payload: ExpoValue): void {
+    try {
+      if (this.appContext.isActive()) this.emit(name, payload);
+    } catch (error) {
+      console.warn(
+        '[ExpoHarmonyNative] ExpoSpeechRecognition emit(' +
+          name +
+          ') failed: ' +
+          JSON.stringify(error),
+      );
+    }
+  }
+
+  private normalizeLanguage(language?: string): string {
+    if (language === undefined || language.length === 0) return DEFAULT_LANGUAGE;
+    const normalized: string = language.replace('_', '-');
+    if (normalized.toLowerCase() === 'zh') return 'zh-CN';
+    if (normalized.toLowerCase() === 'en') return 'en-US';
+    return normalized;
+  }
+
+  private granted(canAskAgain: boolean = true): PermissionResponse {
+    return { status: 'granted', granted: true, canAskAgain: canAskAgain, expires: 'never' };
+  }
+
+  private denied(canAskAgain: boolean = true): PermissionResponse {
+    return { status: 'denied', granted: false, canAskAgain: canAskAgain, expires: 'never' };
+  }
+
+  private speechRecognizerPermission(): PermissionResponse {
+    // HarmonyOS does not expose a second speech-recognizer permission. This
+    // mirrors the community module's Android behavior.
+    return this.granted(false);
+  }
+
+  private async getMicrophonePermission(): Promise<PermissionResponse> {
+    try {
+      const tokenId: number = this.appContext.uiAbilityContext.applicationInfo.accessTokenId;
+      const status = await abilityAccessCtrl.createAtManager()
+        .checkAccessToken(tokenId, MICROPHONE_PERMISSION);
+      return status === abilityAccessCtrl.GrantStatus.PERMISSION_GRANTED
+        ? this.granted()
+        : this.denied();
+    } catch (_error) {
+      return this.denied();
+    }
+  }
+
+  private async requestMicrophonePermission(): Promise<PermissionResponse> {
+    try {
+      const result = await abilityAccessCtrl.createAtManager().requestPermissionsFromUser(
+        this.appContext.uiAbilityContext,
+        [MICROPHONE_PERMISSION],
+      );
+      const granted: boolean =
+        result.authResults[0] === abilityAccessCtrl.GrantStatus.PERMISSION_GRANTED;
+      const dialogWasShown: boolean =
+        result.dialogShownResults === undefined || result.dialogShownResults[0] === true;
+      return granted ? this.granted() : this.denied(dialogWasShown);
+    } catch (_error) {
+      return this.denied();
+    }
+  }
+
+  private startFromJavaScript(options: RecognitionOptions): void {
+    if (this.state !== 'inactive') {
+      this.safeEmit('error', {
+        error: 'busy',
+        message: 'A speech recognition session is already active.',
+        code: -1,
+      });
+      return;
+    }
+
+    if (!this.available()) {
+      this.safeEmit('error', {
+        error: 'service-not-allowed',
+        message: 'HarmonyOS Core Speech Kit and Audio Capturer are required.',
+        code: -1,
+      });
+      this.safeEmit('end', null);
+      return;
+    }
+
+    this.beginSession(options);
+    const expectedGeneration: number = this.generation;
+    this.startSession(options, expectedGeneration).catch((error: Object): void => {
+      if (!this.isCurrentGeneration(expectedGeneration)) return;
+      this.finishWithError(
+        this.mapErrorCode(this.errorCode(error), this.errorMessage(error)),
+        this.errorMessage(error),
+        this.errorCode(error),
+      );
+    });
+  }
+
+  private beginSession(options: RecognitionOptions): void {
+    this.generation = this.generation + 1;
+    this.state = 'starting';
+    this.sessionKind = options.audioSource === undefined ? 'microphone' : 'audioFile';
+    this.sessionId =
+      'expo-asr-' + this.sessionKind + '-' + Date.now().toString() + '-' + this.generation.toString();
+    this.lastTranscript = '';
+    this.hasFinalResult = false;
+    this.reportInterimResults = options.interimResults === true;
+    this.audioRemainder = new Uint8Array(0);
+    this.pendingFile = null;
+    this.emittedAudioStart = false;
+    this.emittedAudioEnd = false;
+    this.emittedEnd = false;
+  }
+
+  private isCurrentGeneration(expectedGeneration: number): boolean {
+    // Async permission/file/engine work belongs only to the pending start that
+    // created it. In particular, a stop() that wins this race must prevent a
+    // late engine from being attached and started.
+    return this.generation === expectedGeneration && this.state === 'starting';
+  }
+
+  private isActiveSession(expectedSessionId: string): boolean {
+    return expectedSessionId === this.sessionId && this.state !== 'inactive';
+  }
+
+  private async startSession(
+    options: RecognitionOptions,
+    expectedGeneration: number,
+  ): Promise<void> {
+    // A previous session may have emitted `end` after detaching its native
+    // resources but before Audio Capturer has finished releasing them. A new
+    // generation can be created immediately, but it must not acquire native
+    // resources until that detached cleanup is complete.
+    await this.cleanupPromise;
+    if (!this.isCurrentGeneration(expectedGeneration)) return;
+
+    const permission: PermissionResponse = await this.getMicrophonePermission();
+    if (!this.isCurrentGeneration(expectedGeneration)) return;
+    if (!permission.granted) {
+      this.finishWithError(
+        'not-allowed',
+        'Microphone permission has not been granted.',
+        -1,
+      );
+      return;
+    }
+
+    if (options.recordingOptions?.persist === true) {
+      this.finishWithError(
+        'audio-capture',
+        'Persisting speech-recognition audio is not supported on HarmonyOS.',
+        -1,
+      );
+      return;
+    }
+
+    if (options.audioSource !== undefined) {
+      try {
+        this.pendingFile = await this.readAudioFile(options.audioSource);
+      } catch (error) {
+        if (this.isCurrentGeneration(expectedGeneration)) {
+          this.finishWithError('audio-capture', this.errorMessage(error), this.errorCode(error));
+        }
+        return;
+      }
+      if (!this.isCurrentGeneration(expectedGeneration)) return;
+    }
+
+    let engine: speechRecognizer.SpeechRecognitionEngine;
+    try {
+      engine = await this.createEngine(options);
+    } catch (error) {
+      if (this.isCurrentGeneration(expectedGeneration)) {
+        this.finishWithError(
+          this.mapErrorCode(this.errorCode(error), this.errorMessage(error)),
+          this.errorMessage(error),
+          this.errorCode(error),
+        );
+      }
+      return;
+    }
+
+    if (!this.isCurrentGeneration(expectedGeneration)) {
+      engine.shutdown();
+      return;
+    }
+
+    this.engine = engine;
+    engine.setListener(new RecognitionListenerAdapter(this));
+    try {
+      engine.startListening(this.startParams());
+    } catch (error) {
+      this.finishWithError(
+        this.mapErrorCode(this.errorCode(error), this.errorMessage(error)),
+        this.errorMessage(error),
+        this.errorCode(error),
+      );
+    }
+  }
+
+  private async createEngine(
+    options: RecognitionOptions,
+  ): Promise<speechRecognizer.SpeechRecognitionEngine> {
+    const language: string = this.normalizeLanguage(options.lang);
+    const offlineOnly: boolean = options.requiresOnDeviceRecognition === true;
+    try {
+      return await speechRecognizer.createEngine({
+        language: language,
+        online: offlineOnly ? 1 : 0,
+      });
+    } catch (error) {
+      if (offlineOnly) throw new Error(this.errorMessage(error));
+      console.warn(
+        '[ExpoHarmonyNative] ExpoSpeechRecognition online engine failed; retrying offline: ' +
+          JSON.stringify(error),
+      );
+      return await speechRecognizer.createEngine({ language: language, online: 1 });
+    }
+  }
+
+  private startParams(): speechRecognizer.StartParams {
+    return {
+      sessionId: this.sessionId,
+      audioInfo: {
+        audioType: 'pcm',
+        sampleRate: 16000,
+        soundChannel: 1,
+        sampleBit: 16,
+      },
+    };
+  }
+
+  private async queryLocales(online: number): Promise<Array<string>> {
+    let engine: speechRecognizer.SpeechRecognitionEngine | null = null;
+    try {
+      engine = await speechRecognizer.createEngine({
+        language: 'zh-CN',
+        online: online,
+      });
+      return await engine.listLanguages({
+        sessionId: 'expo-asr-locales-' + online.toString() + '-' + Date.now().toString(),
+      });
+    } catch (_error) {
+      return new Array<string>();
+    } finally {
+      if (engine !== null) engine.shutdown();
+    }
+  }
+
+  private async getSupportedLocales(): Promise<ExpoValue> {
+    if (!canIUse(ASR_SYSCAP)) {
+      return { locales: new Array<string>(), installedLocales: new Array<string>() };
+    }
+    if (this.state !== 'inactive') {
+      throw new Error('Supported locales cannot be queried while recognition is active.');
+    }
+
+    const locales: Array<string> = await this.queryLocales(0);
+    const installedLocales: Array<string> = await this.queryLocales(1);
+    return {
+      locales: locales.length > 0 ? locales : installedLocales,
+      installedLocales: installedLocales,
+    };
+  }
+
+  private async createCapturer(): Promise<audio.AudioCapturer> {
+    const options: audio.AudioCapturerOptions = {
+      streamInfo: {
+        samplingRate: audio.AudioSamplingRate.SAMPLE_RATE_16000,
+        channels: audio.AudioChannel.CHANNEL_1,
+        sampleFormat: audio.AudioSampleFormat.SAMPLE_FORMAT_S16LE,
+        encodingType: audio.AudioEncodingType.ENCODING_TYPE_RAW,
+      },
+      capturerInfo: {
+        source: audio.SourceType.SOURCE_TYPE_VOICE_RECOGNITION,
+        capturerFlags: 0,
+      },
+    };
+    return await audio.createAudioCapturer(options);
+  }
+
+  private async startCapture(expectedSessionId: string): Promise<void> {
+    try {
+      const capturer: audio.AudioCapturer = await this.createCapturer();
+      if (expectedSessionId !== this.sessionId || this.state !== 'recognizing') {
+        await capturer.release();
+        return;
+      }
+      this.capturer = capturer;
+      capturer.on('readData', this.readDataCallback);
+      await capturer.start();
+      if (expectedSessionId !== this.sessionId || this.state !== 'recognizing') {
+        await this.stopCapture();
+        return;
+      }
+      this.emitAudioStart();
+    } catch (error) {
+      if (this.isActiveSession(expectedSessionId)) {
+        this.finishWithError('audio-capture', this.errorMessage(error), this.errorCode(error));
+      }
+    }
+  }
+
+  private concat(left: Uint8Array, right: Uint8Array): Uint8Array {
+    const combined = new Uint8Array(left.length + right.length);
+    combined.set(left, 0);
+    combined.set(right, left.length);
+    return combined;
+  }
+
+  private writeCapturedAudio(buffer: ArrayBuffer): void {
+    const engine = this.engine;
+    if (engine === null || this.state !== 'recognizing') return;
+    const combined: Uint8Array = this.concat(this.audioRemainder, new Uint8Array(buffer));
+    let offset: number = 0;
+    while (combined.length - offset >= FRAME_BYTES) {
+      const frame = new Uint8Array(FRAME_BYTES);
+      frame.set(combined.subarray(offset, offset + FRAME_BYTES));
+      try {
+        engine.writeAudio(this.sessionId, frame);
+      } catch (error) {
+        this.finishWithError('audio-capture', this.errorMessage(error), this.errorCode(error));
+        return;
+      }
+      offset = offset + FRAME_BYTES;
+    }
+    const rest: number = combined.length - offset;
+    this.audioRemainder = new Uint8Array(rest);
+    if (rest > 0) this.audioRemainder.set(combined.subarray(offset));
+  }
+
+  private flushAudioRemainder(): void {
+    if (this.audioRemainder.length === 0 || this.engine === null) return;
+    const frame = new Uint8Array(FRAME_BYTES);
+    frame.set(this.audioRemainder);
+    this.engine.writeAudio(this.sessionId, frame);
+    this.audioRemainder = new Uint8Array(0);
+  }
+
+  private stopFromJavaScript(): void {
+    if (this.state === 'inactive') {
+      this.safeEmit('end', null);
+      return;
+    }
+    if (this.state === 'stopping') return;
+    if (this.state === 'starting' && this.engine === null) {
+      // No native engine exists to deliver onComplete after finish(). Ending
+      // locally also increments generation, invalidating the pending async
+      // start pipeline before it can create or attach an engine.
+      this.finishSession();
+      return;
+    }
+    this.state = 'stopping';
+    this.stopAndFinish().catch((error: Object): void => {
+      if (this.state !== 'inactive') {
+        this.finishWithError('unknown', this.errorMessage(error), this.errorCode(error));
+      }
+    });
+  }
+
+  private async stopAndFinish(): Promise<void> {
+    await this.stopCapture();
+    this.pendingFile = null;
+    this.flushAudioRemainder();
+    this.engine?.finish(this.sessionId);
+  }
+
+  private abortFromJavaScript(): void {
+    this.safeEmit('error', {
+      error: 'aborted',
+      message: 'Speech recognition aborted.',
+      code: -1,
+    });
+    if (this.state === 'inactive') {
+      this.safeEmit('end', null);
+      return;
+    }
+
+    this.state = 'stopping';
+    try {
+      this.engine?.cancel(this.sessionId);
+    } catch (_error) {
+      // Cancellation is best-effort; cleanup below is authoritative.
+    }
+    this.finishSession();
+  }
+
+  private async stopCapture(): Promise<void> {
+    const capturer = this.capturer;
+    this.capturer = null;
+    if (capturer === null) return;
+    try {
+      capturer.off('readData', this.readDataCallback);
+    } catch (_error) {}
+    try {
+      await capturer.stop();
+    } catch (_error) {}
+    try {
+      await capturer.release();
+    } catch (_error) {}
+    this.emitAudioEnd();
+  }
+
+  private async readAudioFile(options: AudioSourceOptions): Promise<AudioFileData> {
+    if (options.uri.length === 0) throw new Error('audioSource.uri must not be empty.');
+    if (options.uri.startsWith('http://') || options.uri.startsWith('https://')) {
+      throw new Error('Remote audioSource URIs are not supported on HarmonyOS.');
+    }
+
+    let bytes: Uint8Array;
+    if (options.uri.startsWith('asset://')) {
+      const assetPath: string = options.uri.substring('asset://'.length);
+      bytes = await this.appContext.uiAbilityContext.resourceManager
+        .getRawFileContent('assets/' + assetPath);
+    } else {
+      const source: string = options.uri.startsWith('file://')
+        ? options.uri.substring('file://'.length)
+        : options.uri;
+      const file = fs.openSync(source, fs.OpenMode.READ_ONLY);
+      try {
+        const stat = fs.statSync(file.fd);
+        bytes = new Uint8Array(stat.size);
+        let bytesRead: number = 0;
+        while (bytesRead < bytes.length) {
+          const readCount: number = fs.readSync(file.fd, bytes.subarray(bytesRead), {
+            length: bytes.length - bytesRead,
+          });
+          if (readCount <= 0) {
+            throw new Error(
+              'The audioSource file ended before all declared bytes could be read.',
+            );
+          }
+          bytesRead = bytesRead + readCount;
+        }
+      } finally {
+        fs.closeSync(file);
+      }
+    }
+
+    const chunkDelayMillis: number =
+      options.chunkDelayMillis === undefined
+        ? DEFAULT_CHUNK_DELAY_MS
+        : Math.max(0, options.chunkDelayMillis);
+    return this.parseAudioFile(bytes, options, chunkDelayMillis);
+  }
+
+  private readAscii(bytes: Uint8Array, offset: number, count: number): string {
+    let output: string = '';
+    for (let index: number = 0; index < count; index++) {
+      output = output + String.fromCharCode(bytes[offset + index]);
+    }
+    return output;
+  }
+
+  private littleEndian16(bytes: Uint8Array, offset: number): number {
+    return bytes[offset] | (bytes[offset + 1] << 8);
+  }
+
+  private littleEndian32(bytes: Uint8Array, offset: number): number {
+    return (
+      bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24)
+    ) >>> 0;
+  }
+
+  private parseAudioFile(
+    bytes: Uint8Array,
+    options: AudioSourceOptions,
+    chunkDelayMillis: number,
+  ): AudioFileData {
+    if (
+      bytes.length >= 12 &&
+      this.readAscii(bytes, 0, 4) === 'RIFF' &&
+      this.readAscii(bytes, 8, 4) === 'WAVE'
+    ) {
+      return this.parseWav(bytes, chunkDelayMillis);
+    }
+
+    const sampleRate: number = options.sampleRate ?? 16000;
+    const channels: number = options.audioChannels ?? 1;
+    const audioEncoding: number = options.audioEncoding ?? PCM_16BIT_ANDROID_ENCODING;
+    if (sampleRate !== 16000 || channels !== 1 || audioEncoding !== PCM_16BIT_ANDROID_ENCODING) {
+      throw new Error(
+        'HarmonyOS raw audioSource input must be 16 kHz, mono, signed 16-bit little-endian PCM.',
+      );
+    }
+    return {
+      bytes: bytes,
+      sampleRate: sampleRate,
+      channels: channels,
+      sampleBits: 16,
+      chunkDelayMillis: chunkDelayMillis,
+    };
+  }
+
+  private parseWav(bytes: Uint8Array, chunkDelayMillis: number): AudioFileData {
+    let offset: number = 12;
+    let audioFormat: number = 0;
+    let channels: number = 0;
+    let sampleRate: number = 0;
+    let sampleBits: number = 0;
+    let payload: Uint8Array | null = null;
+
+    while (offset + 8 <= bytes.length) {
+      const chunkName: string = this.readAscii(bytes, offset, 4);
+      const chunkSize: number = this.littleEndian32(bytes, offset + 4);
+      const payloadStart: number = offset + 8;
+      const payloadEnd: number = payloadStart + chunkSize;
+      if (payloadEnd > bytes.length) break;
+
+      if (chunkName === 'fmt ' && chunkSize >= 16) {
+        audioFormat = this.littleEndian16(bytes, payloadStart);
+        channels = this.littleEndian16(bytes, payloadStart + 2);
+        sampleRate = this.littleEndian32(bytes, payloadStart + 4);
+        sampleBits = this.littleEndian16(bytes, payloadStart + 14);
+      } else if (chunkName === 'data') {
+        // Keep a view into the input buffer instead of temporarily holding a
+        // second full copy of the WAV payload in memory.
+        payload = bytes.subarray(payloadStart, payloadEnd);
+      }
+      offset = payloadEnd + (chunkSize % 2);
+    }
+
+    if (payload === null) throw new Error('The WAV audioSource has no data chunk.');
+    if (audioFormat !== 1 || sampleRate !== 16000 || channels !== 1 || sampleBits !== 16) {
+      throw new Error(
+        'HarmonyOS WAV audioSource input must be PCM, 16 kHz, mono, and signed 16-bit.',
+      );
+    }
+    return {
+      bytes: payload,
+      sampleRate: sampleRate,
+      channels: channels,
+      sampleBits: sampleBits,
+      chunkDelayMillis: chunkDelayMillis,
+    };
+  }
+
+  private delay(milliseconds: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), milliseconds);
+    });
+  }
+
+  private async feedPendingFile(expectedSessionId: string): Promise<void> {
+    const source = this.pendingFile;
+    const engine = this.engine;
+    this.pendingFile = null;
+    if (source === null || engine === null) return;
+
+    await this.delay(0);
+    if (expectedSessionId !== this.sessionId || this.state !== 'recognizing') return;
+    this.emitAudioStart();
+    let offset: number = 0;
+    try {
+      while (offset < source.bytes.length) {
+        if (
+          this.engine !== engine ||
+          this.sessionId !== expectedSessionId ||
+          this.state !== 'recognizing'
+        ) {
+          return;
+        }
+        const remaining: number = source.bytes.length - offset;
+        const size: number = remaining >= FRAME_BYTES ? FRAME_BYTES : remaining;
+        const frame = new Uint8Array(FRAME_BYTES);
+        frame.set(source.bytes.subarray(offset, offset + size));
+        engine.writeAudio(expectedSessionId, frame);
+        offset = offset + size;
+        await this.delay(source.chunkDelayMillis);
+      }
+      this.emitAudioEnd();
+      engine.finish(expectedSessionId);
+    } catch (error) {
+      if (this.isActiveSession(expectedSessionId)) {
+        this.finishWithError('audio-capture', this.errorMessage(error), this.errorCode(error));
+      }
+    }
+  }
+
+  onNativeStart(sessionId: string, _eventMessage: string): void {
+    if (sessionId !== this.sessionId || this.state !== 'starting') return;
+    this.state = 'recognizing';
+    this.safeEmit('start', null);
+    if (this.sessionKind === 'microphone') {
+      this.startCapture(sessionId);
+    } else {
+      this.feedPendingFile(sessionId);
+    }
+  }
+
+  onNativeEvent(sessionId: string, eventCode: number, _eventMessage: string): void {
+    if (sessionId !== this.sessionId || this.state === 'inactive') return;
+    if (eventCode === 1) this.emitAudioStart();
+    if (eventCode === 3) this.emitAudioEnd();
+  }
+
+  onNativeResult(
+    sessionId: string,
+    result: speechRecognizer.SpeechRecognitionResult,
+  ): void {
+    if (sessionId !== this.sessionId || this.state === 'inactive') return;
+    this.lastTranscript = result.result;
+    if (result.isFinal) this.hasFinalResult = true;
+    if (!result.isFinal && !this.reportInterimResults) return;
+    if (result.result.length === 0) return;
+    this.emitResult(result.result, result.isFinal);
+  }
+
+  onNativeComplete(sessionId: string, _eventMessage: string): void {
+    if (sessionId !== this.sessionId || this.state === 'inactive') return;
+    if (this.lastTranscript.length === 0) {
+      this.safeEmit('nomatch', null);
+    } else if (!this.hasFinalResult) {
+      this.emitResult(this.lastTranscript, true);
+    }
+    this.finishSession();
+  }
+
+  onNativeError(sessionId: string, errorCode: number, errorMessage: string): void {
+    if (sessionId !== this.sessionId || this.state === 'inactive') return;
+    this.finishWithError(this.mapErrorCode(errorCode, errorMessage), errorMessage, errorCode);
+  }
+
+  private emitResult(transcript: string, isFinal: boolean): void {
+    const alternative: RecognitionResultItemPayload = {
+      transcript: transcript,
+      confidence: -1,
+      segments: new Array<ExpoValue>(),
+    };
+    const payload: RecognitionResultPayload = {
+      isFinal: isFinal,
+      results: [alternative],
+    };
+    this.safeEmit('result', payload);
+  }
+
+  private emitAudioStart(): void {
+    if (this.emittedAudioStart) return;
+    this.emittedAudioStart = true;
+    this.safeEmit('audiostart', { uri: null });
+  }
+
+  private emitAudioEnd(): void {
+    if (this.emittedAudioEnd || !this.emittedAudioStart) return;
+    this.emittedAudioEnd = true;
+    this.safeEmit('audioend', { uri: null });
+  }
+
+  private mapErrorCode(code: number | undefined, message: string): string {
+    const lower: string = message.toLowerCase();
+    if (code === 1002200006 || lower.includes('busy')) return 'busy';
+    if (lower.includes('permission') || lower.includes('not allowed')) return 'not-allowed';
+    if (
+      lower.includes('language') ||
+      lower.includes('locale') ||
+      lower.includes('model')
+    ) {
+      return 'language-not-supported';
+    }
+    if (lower.includes('network')) return 'network';
+    if (lower.includes('speech') || lower.includes('empty') || lower.includes('no match')) {
+      return 'no-speech';
+    }
+    if (code === 1002200003 || code === 1002200010) return 'audio-capture';
+    if (
+      code === 1002200001 ||
+      code === 1002200002 ||
+      code === 1002200007 ||
+      code === 1002200008
+    ) {
+      return 'service-not-allowed';
+    }
+    return 'unknown';
+  }
+
+  private errorMessage(error: Object): string {
+    const native = error as NativeError;
+    return native.message === undefined ? JSON.stringify(error) : native.message;
+  }
+
+  private errorCode(error: Object): number | undefined {
+    return (error as NativeError).code;
+  }
+
+  private finishWithError(code: string, message: string, nativeCode?: number): void {
+    if (this.state === 'inactive') return;
+    const payload: RecognitionErrorPayload = {
+      error: code,
+      message: message,
+    };
+    if (nativeCode !== undefined) payload.code = nativeCode;
+    this.safeEmit('error', payload);
+    this.finishSession();
+  }
+
+  private finishSession(): void {
+    if (this.state === 'inactive') return;
+
+    // Detach every piece of mutable session state before asynchronous native
+    // cleanup starts. This lets abort(); start(...) create a new generation
+    // immediately without the old cleanup shutting down or clearing it later.
+    const capturer = this.capturer;
+    const engine = this.engine;
+    const shouldEmitAudioEnd: boolean = this.emittedAudioStart && !this.emittedAudioEnd;
+    const shouldEmitEnd: boolean = !this.emittedEnd;
+    if (capturer !== null) {
+      try {
+        capturer.off('readData', this.readDataCallback);
+      } catch (_error) {}
+    }
+
+    this.state = 'inactive';
+    this.generation = this.generation + 1;
+    this.capturer = null;
+    this.engine = null;
+    this.pendingFile = null;
+    this.audioRemainder = new Uint8Array(0);
+    this.sessionKind = null;
+    this.sessionId = '';
+    this.emittedAudioEnd = true;
+    this.emittedEnd = true;
+
+    this.cleanupPromise = this.cleanupPromise.then(
+      (): Promise<void> => this.releaseDetachedSession(capturer, engine),
+    );
+
+    if (shouldEmitAudioEnd) this.safeEmit('audioend', { uri: null });
+    if (shouldEmitEnd) this.safeEmit('end', null);
+  }
+
+  private async releaseDetachedSession(
+    capturer: audio.AudioCapturer | null,
+    engine: speechRecognizer.SpeechRecognitionEngine | null,
+  ): Promise<void> {
+    if (capturer !== null) {
+      try {
+        await capturer.stop();
+      } catch (_error) {}
+      try {
+        await capturer.release();
+      } catch (_error) {}
+    }
+    if (engine !== null) {
+      try {
+        engine.shutdown();
+      } catch (_error) {}
+    }
+  }
+
+  private cancelNativeWork(): void {
+    if (this.state === 'inactive') return;
+    try {
+      this.engine?.cancel(this.sessionId);
+    } catch (_error) {}
+    this.finishSession();
+  }
+}
+
+export class ExpoSpeechRecognitionHarmonyPackage extends RNOHPackage {
+  constructor(ctx: RNPackageContext) {
+    super(ctx);
+    expoRoute3ModuleRegistry.register(
+      ExpoSpeechRecognitionModule.NAME,
+      (appContext: AppContext): Module => new ExpoSpeechRecognitionModule(appContext),
+    );
+  }
+
+  override getDebugName(): string {
+    return 'expo-speech-recognition-harmony';
+  }
+}
+
+export default ExpoSpeechRecognitionHarmonyPackage;

--- a/harmony/src/main/module.json5
+++ b/harmony/src/main/module.json5
@@ -1,0 +1,7 @@
+{
+  module: {
+    name: "expo_speech_recognition_harmony",
+    type: "har",
+    deviceTypes: ["default"],
+  },
+}

--- a/src/ExpoSpeechRecognitionModule.web.ts
+++ b/src/ExpoSpeechRecognitionModule.web.ts
@@ -324,9 +324,16 @@ const webToNativeEventMap: {
     if (isFinal) {
       const results: ExpoSpeechRecognitionNativeEventMap["result"]["results"] =
         [];
+      const resultList = ev.results[ev.resultIndex];
 
-      for (let i = 0; i < ev.results[ev.resultIndex].length; i++) {
-        const result = ev.results[ev.resultIndex][i];
+      if (!resultList) {
+        return { isFinal: true, results };
+      }
+      for (let i = 0; i < resultList.length; i++) {
+        const result = resultList[i];
+        if (!result) {
+          continue;
+        }
         results.push({
           transcript: result.transcript,
           confidence: result.confidence,
@@ -345,6 +352,9 @@ const webToNativeEventMap: {
 
     for (let i = ev.resultIndex; i < ev.results.length; i++) {
       const resultList = ev.results[i];
+      if (!resultList) {
+        continue;
+      }
 
       for (let j = 0; j < resultList.length; j++) {
         const result = resultList[j];

--- a/src/ExpoWebSpeechRecognition.ts
+++ b/src/ExpoWebSpeechRecognition.ts
@@ -426,14 +426,14 @@ export class ExpoWebSpeechGrammarList implements SpeechGrammarList {
   }
 
   item(index: number): ExpoWebSpeechGrammar {
-    return this.#grammars[index];
+    return this.#grammars[index]!;
   }
 
   addFromString = (grammar: string, weight?: number) => {
     // TODO: parse grammar to html entities (data:application/xml,....)
     this.#grammars.push(new ExpoWebSpeechGrammar(grammar, weight));
     // Set key on this object for compatibility with web SpeechGrammarList API
-    this[this.length - 1] = this.#grammars[this.length - 1];
+    this[this.length - 1] = this.#grammars[this.length - 1]!;
   };
 }
 
@@ -457,7 +457,7 @@ class ExpoSpeechRecognitionResultList implements SpeechRecognitionResultList {
   }
   length: number;
   item(index: number): SpeechRecognitionResult {
-    return this.#results[index];
+    return this.#results[index]!;
   }
   [index: number]: SpeechRecognitionResult;
 
@@ -465,7 +465,7 @@ class ExpoSpeechRecognitionResultList implements SpeechRecognitionResultList {
     this.#results = results;
     this.length = results.length;
     for (let i = 0; i < this.#results.length; i++) {
-      this[i] = this.#results[i];
+      this[i] = this.#results[i]!;
     }
   }
 }
@@ -478,7 +478,7 @@ class ExpoSpeechRecognitionResult implements SpeechRecognitionResult {
   length: number;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/SpeechRecognitionResult/item) */
   item(index: number): SpeechRecognitionAlternative {
-    return this.#alternatives[index];
+    return this.#alternatives[index]!;
   }
   [index: number]: SpeechRecognitionAlternative;
   [Symbol.iterator](): ArrayIterator<SpeechRecognitionAlternative> {
@@ -495,7 +495,7 @@ class ExpoSpeechRecognitionResult implements SpeechRecognitionResult {
     this.length = alternatives.length;
     this.#alternatives = alternatives;
     for (let i = 0; i < alternatives.length; i++) {
-      this[i] = alternatives[i];
+      this[i] = alternatives[i]!;
     }
   }
 }

--- a/src/__tests__/HarmonyContract-test.js
+++ b/src/__tests__/HarmonyContract-test.js
@@ -1,0 +1,169 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require("node:fs");
+const path = require("node:path");
+
+const packageRoot = path.resolve(__dirname, "../..");
+const moduleConfigPath = path.join(packageRoot, "expo-module.config.json");
+const harmonySourcePath = path.join(
+  packageRoot,
+  "harmony/src/main/ets/Index.ets",
+);
+
+const moduleConfig = JSON.parse(fs.readFileSync(moduleConfigPath, "utf8"));
+const harmonySource = fs.readFileSync(harmonySourcePath, "utf8");
+
+describe("Harmony Expo module contract", () => {
+  it("is discoverable by Expo autolinking", () => {
+    expect(moduleConfig.platforms).toContain("harmony");
+    expect(moduleConfig.harmony).toMatchObject({
+      modules: ["ExpoSpeechRecognition"],
+      arktsPackageClass: "ExpoSpeechRecognitionHarmonyPackage",
+      ohPackageName: "@bitfun/expo-speech-recognition-harmony",
+      harName: "expo_speech_recognition_harmony.har",
+      minApi: 22,
+    });
+  });
+
+  it("exposes every method in the community native module API", () => {
+    const methods = [
+      "start",
+      "stop",
+      "abort",
+      "requestPermissionsAsync",
+      "getPermissionsAsync",
+      "requestMicrophonePermissionsAsync",
+      "getMicrophonePermissionsAsync",
+      "requestSpeechRecognizerPermissionsAsync",
+      "getSpeechRecognizerPermissionsAsync",
+      "getStateAsync",
+      "getSupportedLocales",
+      "getSpeechRecognitionServices",
+      "getDefaultRecognitionService",
+      "getAssistantService",
+      "supportsOnDeviceRecognition",
+      "supportsRecording",
+      "isRecognitionAvailable",
+      "androidTriggerOfflineModelDownload",
+      "setCategoryIOS",
+      "getAudioSessionCategoryAndOptionsIOS",
+      "setAudioSessionActiveIOS",
+    ];
+
+    for (const method of methods) {
+      expect(harmonySource).toMatch(
+        new RegExp(String.raw`\.(?:asyncFunction|function)\('${method}'`),
+      );
+    }
+    expect(harmonySource).not.toContain("transcribeAudioFileAsync");
+  });
+
+  it("registers every public native event", () => {
+    const events = [
+      "audiostart",
+      "audioend",
+      "end",
+      "error",
+      "nomatch",
+      "result",
+      "soundstart",
+      "soundend",
+      "speechstart",
+      "speechend",
+      "start",
+      "languagedetection",
+      "volumechange",
+    ];
+
+    for (const event of events) {
+      expect(harmonySource).toContain(`.event('${event}')`);
+    }
+  });
+
+  it("uses the community result and audio event payload shapes", () => {
+    expect(harmonySource).toContain("confidence: -1");
+    expect(harmonySource).toContain("segments: new Array<ExpoValue>()");
+    expect(harmonySource).toContain(
+      "this.safeEmit('audiostart', { uri: null })",
+    );
+    expect(harmonySource).toContain("this.safeEmit('audioend', { uri: null })");
+    expect(harmonySource).toContain("type RecognitionState = 'inactive'");
+  });
+
+  it("invalidates an asynchronous start when stop wins before engine creation", () => {
+    expect(harmonySource).toContain(
+      "return this.generation === expectedGeneration && this.state === 'starting';",
+    );
+
+    const stopStart = harmonySource.indexOf(
+      "private stopFromJavaScript(): void",
+    );
+    const stopEnd = harmonySource.indexOf(
+      "private async stopAndFinish(): Promise<void>",
+    );
+    const stopImplementation = harmonySource.slice(stopStart, stopEnd);
+    expect(stopImplementation).toContain(
+      "if (this.state === 'starting' && this.engine === null)",
+    );
+    expect(stopImplementation.indexOf("this.finishSession();")).toBeLessThan(
+      stopImplementation.indexOf("this.state = 'stopping';"),
+    );
+  });
+
+  it("allows an active session to abort and restart before native cleanup finishes", () => {
+    expect(harmonySource).toContain(
+      "private cleanupPromise: Promise<void> = Promise.resolve();",
+    );
+
+    const startSessionStart = harmonySource.indexOf(
+      "private async startSession(",
+    );
+    const startSessionEnd = harmonySource.indexOf(
+      "private async createEngine(",
+    );
+    const startSessionImplementation = harmonySource.slice(
+      startSessionStart,
+      startSessionEnd,
+    );
+    expect(startSessionImplementation).toContain("await this.cleanupPromise;");
+
+    const finishStart = harmonySource.indexOf("private finishSession(): void");
+    const finishEnd = harmonySource.indexOf("private cancelNativeWork(): void");
+    const finishImplementation = harmonySource.slice(finishStart, finishEnd);
+    expect(finishStart).toBeGreaterThan(-1);
+    expect(finishImplementation).toContain("const capturer = this.capturer;");
+    expect(finishImplementation).toContain("const engine = this.engine;");
+    expect(finishImplementation).toContain("this.capturer = null;");
+    expect(finishImplementation).toContain("this.engine = null;");
+    expect(finishImplementation).toContain(
+      "this.releaseDetachedSession(capturer, engine)",
+    );
+    expect(finishImplementation).not.toContain("await this.stopCapture();");
+
+    const detachEngine = finishImplementation.indexOf("this.engine = null;");
+    const queueCleanup = finishImplementation.indexOf(
+      "this.cleanupPromise = this.cleanupPromise.then(",
+    );
+    const emitEnd = finishImplementation.indexOf(
+      "if (shouldEmitEnd) this.safeEmit('end', null);",
+    );
+    expect(detachEngine).toBeLessThan(queueCleanup);
+    expect(queueCleanup).toBeLessThan(emitEnd);
+  });
+
+  it("does not contain machine-local paths or DevEco configuration", () => {
+    const files = [
+      moduleConfigPath,
+      harmonySourcePath,
+      path.join(packageRoot, "harmony/oh-package.json5"),
+    ];
+    const contents = files
+      .map((file) => fs.readFileSync(file, "utf8"))
+      .join("\n");
+
+    expect(contents).not.toMatch(/\/Users\//);
+    expect(contents).not.toMatch(/\/Applications\/DevEco-Studio/);
+    expect(
+      fs.existsSync(path.join(packageRoot, "harmony/deveco-cli.toml")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add a HarmonyOS API 22 Expo Route 3 native module under `harmony/`
- preserve the existing public JS API and event payloads for live microphone recognition
- support local `asset://`, `file://`, and absolute 16 kHz mono PCM/WAV transcription through the existing `audioSource` option
- add explicit permission, locale, capability, unsupported-option, and session cleanup behavior
- make abort followed by an immediate restart safe while old native resources finish releasing
- add Harmony autolinking metadata, package docs, a changeset, and CI execution for the contract tests
- keep the web polyfill compatible with strict TypeScript 6 indexed access checks

This requires an Expo build containing the Harmony Route 3 runtime; stock Expo Go cannot load the new native module. The runtime dependency is being reviewed separately in [BitFun devkit_sdk PR #18](https://github.com/BitFun-Platform/devkit_sdk/pull/18).

## Runtime acceptance

Built, signed, installed, and launched a Release HAP on a HarmonyOS 6.0.2 / API 22 simulator. The final native source SHA-256 was `ce1a04ec4251d812265d9634febba5c8a783bb9a9b5dc7ad63abc6f787cdd02f` and the signed HAP SHA-256 was `b57842db6368da097ee7982943ad3228a0676e896f03c4175b41626feb918617`.

A bundled local Chinese WAV produced the real final transcript `今天天气很好。` with this event order:

`start -> audiostart -> audioend -> result(isFinal=true) -> end`

The run also passed module availability, microphone permission, installed locale, inactive-state recovery, cold launch, and same-process background/foreground recovery. No probe line reported `FAIL`.

## Checks

- `npm test -- --runInBand` — 7/7 passed
- `npm run lint`
- `npm run ts:check`
- `npm run build`
- Prettier check
- `npm pack --dry-run` (Harmony source/config included; local build artifacts excluded)
- DevEco Hvigor Release HAP build — `BUILD SUCCESSFUL`
