### PR TITLE
fix(ios): resolve permission requests from the callback results

### DIFF
--- a/.changeset/callback-permission-results.md
+++ b/.changeset/callback-permission-results.md
@@ -1,0 +1,5 @@
+---
+"expo-speech-recognition": patch
+---
+
+fix ios permission requests resolving granted: false right after the user grants

--- a/ios/EXSpeechRecognitionPermissionRequester.swift
+++ b/ios/EXSpeechRecognitionPermissionRequester.swift
@@ -12,20 +12,33 @@ public class EXSpeechRecognitionPermissionRequester: NSObject, EXPermissionsRequ
   ) {
     SFSpeechRecognizer.requestAuthorization { status in
       if status != .authorized {
-        resolve(self.getPermissions())
+        resolve(self.permissionsResult(
+          speechPermission: status,
+          recordPermission: AVAudioSession.sharedInstance().recordPermission
+        ))
         return
       }
       AVAudioSession.sharedInstance().requestRecordPermission { authorized in
-        resolve(self.getPermissions())
+        resolve(self.permissionsResult(
+          speechPermission: status,
+          recordPermission: authorized ? .granted : .denied
+        ))
       }
     }
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
-    var status: EXPermissionStatus
+    return permissionsResult(
+      speechPermission: SFSpeechRecognizer.authorizationStatus(),
+      recordPermission: AVAudioSession.sharedInstance().recordPermission
+    )
+  }
 
-    let recordPermission = AVAudioSession.sharedInstance().recordPermission
-    let speechPermission = SFSpeechRecognizer.authorizationStatus()
+  private func permissionsResult(
+    speechPermission: SFSpeechRecognizerAuthorizationStatus,
+    recordPermission: AVAudioSession.RecordPermission
+  ) -> [AnyHashable: Any] {
+    var status: EXPermissionStatus
 
     if speechPermission == .authorized && recordPermission == .granted {
       status = EXPermissionStatusGranted

--- a/ios/MicrophoneRequester.swift
+++ b/ios/MicrophoneRequester.swift
@@ -9,14 +9,16 @@ public class MicrophoneRequester: NSObject, EXPermissionsRequester {
     resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: EXPromiseRejectBlock
   ) {
     AVAudioSession.sharedInstance().requestRecordPermission { authorized in
-      resolve(self.getPermissions())
+      resolve(self.permissionsResult(recordPermission: authorized ? .granted : .denied))
     }
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
-    var status: EXPermissionStatus
+    return permissionsResult(recordPermission: AVAudioSession.sharedInstance().recordPermission)
+  }
 
-    let recordPermission = AVAudioSession.sharedInstance().recordPermission
+  private func permissionsResult(recordPermission: AVAudioSession.RecordPermission) -> [AnyHashable: Any] {
+    var status: EXPermissionStatus
 
     if recordPermission == .granted {
       status = EXPermissionStatusGranted

--- a/ios/SpeechRecognizerRequester.swift
+++ b/ios/SpeechRecognizerRequester.swift
@@ -10,14 +10,16 @@ public class SpeechRecognizerRequester: NSObject, EXPermissionsRequester {
     resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: EXPromiseRejectBlock
   ) {
     SFSpeechRecognizer.requestAuthorization { status in
-      resolve(self.getPermissions())
+      resolve(self.permissionsResult(speechPermission: status))
     }
   }
 
   public func getPermissions() -> [AnyHashable: Any] {
-    var status: EXPermissionStatus
+    return permissionsResult(speechPermission: SFSpeechRecognizer.authorizationStatus())
+  }
 
-    let speechPermission = SFSpeechRecognizer.authorizationStatus()
+  private func permissionsResult(speechPermission: SFSpeechRecognizerAuthorizationStatus) -> [AnyHashable: Any] {
+    var status: EXPermissionStatus
 
     if speechPermission == .authorized {
       status = EXPermissionStatusGranted


### PR DESCRIPTION

the requestRecordPermission callback hands you the result but the requesters ignore it and re-read AVAudioSession.sharedInstance().recordPermission, which can still be .undetermined inside its own grant callback. so the first request after a grant resolved granted: false and the retry worked.

all three requesters now build the response from the callback values. getPermissions() still reads live state, the mapping moved into one shared helper per file so the two paths can't drift. no api change.

when the property is fresh the two paths agree, so behavior only changes in the state where the current code resolves wrong (see the swizzle harness in the issue: callback true + property still undetermined → stock resolves granted: false, this branch resolves granted).

SpeechRecognizerRequester gets the same construction for consistency, happy to drop that file if you'd rather keep the diff minimal.

fixes #167

