### PR TITLE
fix(android): support speech recognition in minified release builds

### DIFF
--- a/.changeset/tidy-records-smile.md
+++ b/.changeset/tidy-records-smile.md
@@ -1,0 +1,5 @@
+---
+"expo-speech-recognition": patch
+---
+
+Fix Android speech recognition in minified release builds by generating optimized Expo Modules record metadata. Pass string-list intent options using Android's `ArrayList<String>` extra format.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,38 +1,13 @@
-apply plugin: 'com.android.library'
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
 
 group = 'expo.modules.speechrecognition'
 
 // Read version from package.json
 def packageJson = new groovy.json.JsonSlurper().parseText(file('../package.json').text)
 version = packageJson.version
-
-def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
-apply from: expoModulesCorePlugin
-applyKotlinExpoModulesCorePlugin()
-useCoreDependencies()
-useExpoPublishing()
-
-// If you want to use the managed Android SDK versions from expo-modules-core, set this to true.
-// The Android SDK versions will be bumped from time to time in SDK releases and may introduce breaking changes in your module code.
-// Most of the time, you may like to manage the Android SDK versions yourself.
-def useManagedAndroidSdkVersions = false
-if (useManagedAndroidSdkVersions) {
-  useDefaultAndroidSdkVersions()
-} else {
-  buildscript {
-    // Simple helper that allows the root project to override versions declared by this library.
-    ext.safeExtGet = { prop, fallback ->
-      rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-    }
-  }
-  project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
-    defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 21)
-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
-    }
-  }
-}
 
 android {
   namespace "expo.modules.speechrecognition"

--- a/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechRecognitionOptions.kt
+++ b/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechRecognitionOptions.kt
@@ -4,7 +4,9 @@ import android.media.AudioFormat
 import android.speech.RecognizerIntent
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class SpeechRecognitionOptions : Record {
     @Field
     val interimResults: Boolean? = false
@@ -58,6 +60,7 @@ class SpeechRecognitionOptions : Record {
     val iosVoiceProcessingEnabled: Boolean? = false
 }
 
+@OptimizedRecord
 class VolumeChangeEventOptions : Record {
     @Field
     val enabled: Boolean? = false
@@ -66,6 +69,7 @@ class VolumeChangeEventOptions : Record {
     val intervalMillis: Int? = null
 }
 
+@OptimizedRecord
 class RecordingOptions : Record {
     @Field
     val persist: Boolean = false
@@ -83,6 +87,7 @@ class RecordingOptions : Record {
     val outputEncoding: String? = null
 }
 
+@OptimizedRecord
 class AudioSourceOptions : Record {
     @Field
     val uri: String = ""
@@ -100,11 +105,13 @@ class AudioSourceOptions : Record {
     val chunkDelayMillis: Long? = null
 }
 
+@OptimizedRecord
 class GetSupportedLocaleOptions : Record {
     @Field
     val androidRecognitionServicePackage: String? = null
 }
 
+@OptimizedRecord
 class TriggerOfflineModelDownloadOptions : Record {
     @Field
     val locale: String = "en-US"

--- a/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechService.kt
+++ b/android/src/main/java/expo/modules/speechrecognition/ExpoSpeechService.kt
@@ -405,7 +405,10 @@ class ExpoSpeechService(
                 is String -> intent.putExtra(fieldValue, value)
                 is List<*> -> {
                     if (value.all { it is String }) {
-                        intent.putExtra(fieldValue, value.filterIsInstance<String>().toTypedArray())
+                        intent.putStringArrayListExtra(
+                            fieldValue,
+                            ArrayList(value.filterIsInstance<String>()),
+                        )
                     }
                 }
                 is Double -> intent.putExtra(fieldValue, value.toInt())


### PR DESCRIPTION
## Summary

Fixes Android speech recognition failing in minified release builds when R8 is enabled.

Speech recognition worked correctly in development builds, but calling `start()` in a release build failed immediately, before the microphone started recording. The JavaScript side only received a generic speech recognition error, while Logcat did not contain an actionable native exception.

## Root cause

The speech recognition options are implemented as Expo Modules `Record` types.

The module was still using the legacy `ExpoModulesCorePlugin.gradle` setup, so the current Expo Modules compile-time optimization pipeline was not applied. As a result, record conversion relied on Kotlin reflection, which is not reliable after R8 optimization and obfuscation.

This caused conversion of `SpeechRecognitionOptions` and its nested records to fail before Android's `SpeechRecognizer` was started.

## Changes

- Migrate the Android module to `expo-module-gradle-plugin`.
- Annotate all Expo Modules record types with `@OptimizedRecord`.
- Enable Pika-generated runtime introspection metadata for record conversion.
- Pass string-list values from `androidIntentOptions` using Android's `putStringArrayListExtra`.
- Add a patch changeset for the release.

The Expo Gradle plugin continues to respect `compileSdkVersion`, `minSdkVersion`, and `targetSdkVersion` provided by the consuming root project.

## Result

Speech recognition now starts and returns results in minified Android release builds without requiring application-level ProGuard keep rules.

Development builds continue to work as before.

## Verification

Tested with:

- `npm run lint`
- `npm run ts:check`
- `npm run build`
- package dry-run
- Android release compilation with R8 enabled
- manual testing on a physical Android device using a locally built release APK