### PR TITLE
feat: expo 57

### DIFF
--- a/.changeset/rich-donkeys-repeat.md
+++ b/.changeset/rich-donkeys-repeat.md
@@ -1,0 +1,7 @@
+---
+"expo-speech-recognition": major
+---
+
+Official support for Expo SDK 57 (React Native 0.86). Install `expo-speech-recognition@^57.0.0`.
+
+Apologies for holding out on this release, there were no breaking changes in SDK 57/RN 0.86. But still keeping this package version aligned with the Expo SDK versioning.


### PR DESCRIPTION
Just ensures version lockstep really, no breaking API changes so just leaving it as empty changes with a changeset